### PR TITLE
Clear ReadError from transp.state when setting transp.error to nil

### DIFF
--- a/asyncdispatch2/transports/common.nim
+++ b/asyncdispatch2/transports/common.nim
@@ -469,6 +469,12 @@ template getError*(t: untyped): ref Exception =
   (t).error = nil
   err
 
+template getReadError*(t: untyped): ref Exception =
+  var err = (t).error
+  (t).error = nil
+  (t).state.excl(ReadError)
+  err
+
 template getTransportOsError*(err: OSErrorCode): ref TransportOsError =
   var msg = "(" & $int(err) & ") " & osErrorMsg(err)
   var tre = newException(TransportOsError, msg)

--- a/asyncdispatch2/transports/datagram.nim
+++ b/asyncdispatch2/transports/datagram.nim
@@ -662,14 +662,14 @@ proc peekMessage*(transp: DatagramTransport, msg: var seq[byte],
                   msglen: var int) =
   ## Get access to internal message buffer and length of incoming datagram.
   if ReadError in transp.state:
-    raise transp.getError()
+    raise transp.getReadError()
   shallowCopy(msg, transp.buffer)
   msglen = transp.buflen
 
 proc getMessage*(transp: DatagramTransport): seq[byte] =
   ## Copy data from internal message buffer and return result.
   if ReadError in transp.state:
-    raise transp.getError()
+    raise transp.getReadError()
   if transp.buflen > 0:
     result = newSeq[byte](transp.buflen)
     copyMem(addr result[0], addr transp.buffer[0], transp.buflen)

--- a/asyncdispatch2/transports/stream.nim
+++ b/asyncdispatch2/transports/stream.nim
@@ -1279,7 +1279,7 @@ proc readExactly*(transp: StreamTransport, pbytes: pointer,
   while true:
     if transp.offset == 0:
       if (ReadError in transp.state):
-        raise transp.getError()
+        raise transp.getReadError()
       if (ReadClosed in transp.state) or transp.atEof():
         raise newException(TransportIncompleteError, "Data incomplete!")
 
@@ -1312,7 +1312,7 @@ proc readOnce*(transp: StreamTransport, pbytes: pointer,
   while true:
     if transp.offset == 0:
       if (ReadError in transp.state):
-        raise transp.getError()
+        raise transp.getReadError()
       if (ReadClosed in transp.state) or transp.atEof():
         result = 0
         break
@@ -1356,7 +1356,7 @@ proc readUntil*(transp: StreamTransport, pbytes: pointer, nbytes: int,
 
   while true:
     if ReadError in transp.state:
-      raise transp.getError()
+      raise transp.getReadError()
     if (ReadClosed in transp.state) or transp.atEof():
       raise newException(TransportIncompleteError, "Data incomplete!")
 
@@ -1410,7 +1410,7 @@ proc readLine*(transp: StreamTransport, limit = 0,
 
   while true:
     if (ReadError in transp.state):
-      raise transp.getError()
+      raise transp.getReadError()
     if (ReadClosed in transp.state) or transp.atEof():
       break
 
@@ -1449,7 +1449,7 @@ proc read*(transp: StreamTransport, n = -1): Future[seq[byte]] {.async.} =
   result = newSeq[byte]()
   while true:
     if (ReadError in transp.state):
-      raise transp.getError()
+      raise transp.getReadError()
     if (ReadClosed in transp.state) or transp.atEof():
       break
 
@@ -1493,7 +1493,7 @@ proc consume*(transp: StreamTransport, n = -1): Future[int] {.async.} =
   result = 0
   while true:
     if (ReadError in transp.state):
-      raise transp.getError()
+      raise transp.getReadError()
     if ReadClosed in transp.state or transp.atEof():
       break
 


### PR DESCRIPTION
This PR solves a segfault I've encountered when working with nim-eth-p2p.

The segfault will occur in following setting:
1. Error occurs on `recvfrom` in `readDatagramLoop` and `setReadError` is ran.
2. A `raise transp.getError()` is done in `getMessage` or `peekMessage` in e.g. the transport `function`.
3. On next call of this `getMessage`, it will still have the `ReadError` in the state and again try to get the error, which is nil now.

While I've encountered the issue with use of `DatagramTransport`, I think a similar issue can occur for `StreamTransport`, so I changed also the `getError()` there.

I'm guessing I can remove `getError()` but I've not done it as I see this gets exported?
The two `setReadError` templates could also be moved to common.nim but perhaps not done for above reason? (not to export them?)

~~One thing that still has me puzzled is the actual error I am getting on `recvMsg`.
It is `EAGAIN` error, but the `recvfrom` call is set to blocking and I believe there is no receive timeout set (at least it reads out as 0 when I tested).~~ 
Woops, the `setSocketBlocking` proc naming had me confused, makes sense that is not blocking... and thus EAGAIN sounds normal (and should perhaps be handled even differently?). 