### PR TITLE
fix v3 backwards compatibility for callbacks

### DIFF
--- a/chronos/apps/http/httpserver.nim
+++ b/chronos/apps/http/httpserver.nim
@@ -253,7 +253,8 @@ proc new*(htype: typedesc[HttpServerRef],
           httpHeadersTimeout = 10.seconds,
           maxHeadersSize: int = 8192,
           maxRequestBodySize: int = 1_048_576,
-          dualstack = DualStackType.Auto): HttpResult[HttpServerRef] {.deprecated.} =
+          dualstack = DualStackType.Auto): HttpResult[HttpServerRef] {.
+          deprecated: "raises missing from process callback".} =
 
   proc processCallback2(req: RequestFence): Future[HttpResponseRef] {.
       async: (raises: [CancelledError, HttpResponseError]).} =

--- a/chronos/apps/http/shttpserver.nim
+++ b/chronos/apps/http/shttpserver.nim
@@ -163,7 +163,8 @@ proc new*(htype: typedesc[SecureHttpServerRef],
           maxHeadersSize: int = 8192,
           maxRequestBodySize: int = 1_048_576,
           dualstack = DualStackType.Auto
-         ): HttpResult[SecureHttpServerRef] {.deprecated: "raises missing from process callback".} =
+         ): HttpResult[SecureHttpServerRef] {.
+         deprecated: "raises missing from process callback".} =
   proc processCallback2(req: RequestFence): Future[HttpResponseRef] {.
       async: (raises: [CancelledError, HttpResponseError]).} =
       try:

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -2125,7 +2125,7 @@ proc createStreamServer*(host: TransportAddress,
                          udata: pointer = nil,
                          dualstack = DualStackType.Auto): StreamServer {.
     raises: [TransportOsError].} =
-  createStreamServer(host, StreamCallback(nil), flags, sock, backlog, bufferSize,
+  createStreamServer(host, StreamCallback2(nil), flags, sock, backlog, bufferSize,
                      child, init, cast[pointer](udata), dualstack)
 
 proc createStreamServer*[T](host: TransportAddress,

--- a/tests/testhttpclient.nim
+++ b/tests/testhttpclient.nim
@@ -85,7 +85,7 @@ suite "HTTP client testing suite":
     res
 
   proc createServer(address: TransportAddress,
-                    process: HttpProcessCallback, secure: bool): HttpServerRef =
+                    process: HttpProcessCallback2, secure: bool): HttpServerRef =
     let
       socketFlags = {ServerFlags.TcpNoDelay, ServerFlags.ReuseAddr}
       serverFlags = {HttpServerFlags.Http11Pipeline}


### PR DESCRIPTION
Because the callback types were used explicitly in some consumers of chronos, the change of type introduces a backwards incompatibility preventing a smooth transition to v4 for code that doesn't uses `raises`.

This PR restores backwards compatibility at the expense of introducing a new type with a potentially ugly name - that said, there is already precedence for using numbered names to provide new error handling strategy in chronos.