### PR TITLE
Add missing CLOCK_REALTIME import

### DIFF
--- a/chronos/timer.nim
+++ b/chronos/timer.nim
@@ -109,6 +109,8 @@ elif defined(macosx):
 
 elif defined(posix):
   when asyncTimer == "system":
+    from std/posix import CLOCK_REALTIME
+
     proc fastEpochTime*(): uint64 {.inline, deprecated: "Use Moment.now()".} =
       ## Procedure's resolution is millisecond.
       var t: Timespec


### PR DESCRIPTION
I am trying to run [nim-library-example](https://github.com/logos-co/nim-library-template), and the build command is the following: 

```
exec "nim c" & " --out:build/" & name &
      ".so --threads:on --app:lib --opt:size --noMain --mm:refc --header --undef:metrics --nimMainPrefix:libclock --skipParentCfg:on --nimcache:nimcache -d:asyncTimer=system " &
      extra_params & " " & srcDir & name & ".nim"
``` 

Note the ` -d:asyncTimer=system` argument. 

Running this triggers the following error: 

```
/share/home/arnaud/Work/codex/nim-library-template/vendor/nim-chronos/chronos/timer.nim(115, 29) Error: undeclared identifier: 'CLOCK_REALTIME'
candidates (edit distance, scope distance); see '--spellSuggest': 
 (4, 5): 'clock_gettime'
stack trace: (most recent call last)
/share/home/arnaud/Work/codex/nim-library-template/vendor/nimbus-build-system/vendor/Nim/lib/system/nimscript.nim(427, 18)
/share/home/arnaud/Work/codex/nim-library-template/clock.nimble(31, 3) libclockDynamicTask
/share/home/arnaud/Work/codex/nim-library-template/clock.nimble(24, 5) buildLibrary
/share/home/arnaud/Work/codex/nim-library-template/vendor/nimbus-build-system/vendor/Nim/lib/system/nimscript.nim(264, 7) exec
/share/home/arnaud/Work/codex/nim-library-template/vendor/nimbus-build-system/vendor/Nim/lib/system/nimscript.nim(264, 7) Error: unhandled exception: FAILED: nim c --out:build/libclock.so --threads:on --app:lib --opt:size --noMain --mm:refc --header --undef:metrics --nimMainPrefix:libclock --skipParentCfg:on --nimcache:nimcache -d:asyncTimer=system  --verbosity:0 --hints:off -d:debug library/libclock.nim [OSError]
make: *** [Makefile:53: libclock] Error 1
```

It looks like the import is missing. Adding the line in the PR fixes the issue. 

Note: I am on debian.