### PR TITLE
Revert "chore: unnecessary assign to variable"

### DIFF
--- a/chronos/asyncproc.nim
+++ b/chronos/asyncproc.nim
@@ -506,8 +506,9 @@ when defined(windows):
     if terminateProcess(p.processHandle, 0) != 0'u32:
       ok()
     else:
+      let reason = osLastError()
       if peekProcessExitCode(p).isErr():
-        err(osLastError())
+        err(reason)
       else:
         ok()
 


### PR DESCRIPTION
This commit was merged without review and it is incorrect, because it hides original error code which was retrieved before calling to function `peekProcessExitCode()` (which could introduce another error to the `errno` variable).