### PR TITLE
`fail` should not accept `CancelledError`

### DIFF
--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -231,11 +231,16 @@ proc failImpl(
 template fail*[T](
     future: Future[T], error: ref CatchableError, warn: static bool = false) =
   ## Completes ``future`` with ``error``.
+  when error is CancelledError:
+    {.error: "Only use `cancel` to set `CancelledError` on a future".}
   failImpl(future, error, getSrcLocation())
 
 template fail*[T, E](
     future: InternalRaisesFuture[T, E], error: ref CatchableError,
     warn: static bool = true) =
+  when error is CancelledError:
+    {.error: "Only use `cancel` to set `CancelledError` on a future".}
+
   checkRaises(future, E, error, warn)
   failImpl(future, error, getSrcLocation())
 

--- a/chronos/ratelimit.nim
+++ b/chronos/ratelimit.nim
@@ -25,7 +25,7 @@ type
       # period, there are `capacity` tokens available
 
   BucketWaiter = object
-    future: Future[void]
+    future: Future[void].Raising([CancelledError])
     needed, consumed: int
 
   TokenBucket* = ref object


### PR DESCRIPTION
Cancellation errors are due to `cancel` and shouldn't be set explicitly