### PR TITLE
allow graceful shutdown in asyncengine

### DIFF
--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -1080,6 +1080,14 @@ else:
   proc initAPI() = discard
   proc globalInit() = discard
 
+proc closeSelector*(): Result[void, string] =
+  ## Close selector associated with current thread's dispatcher.
+  try:
+    getThreadDispatcher().selector.close()
+  except IOSelectorsException as e:
+    return err("Exception in closeSelector: " & e.msg)
+  return ok()
+
 proc setThreadDispatcher*(disp: PDispatcher) =
   ## Set current thread's dispatcher instance to ``disp``.
   if not(gDisp.isNil()):


### PR DESCRIPTION
### Description

- This is meant to avoid leaking file descriptors when using Nim libraries.
- Currently, nim-chronos global dispatcher delegates the de-allocation of certain resources to the OS, when an app ends.
- Nim libraries leverage nim-chronos threads, i.e., a Nim library component starts a nim-chronos thread to operate with.
- Certain use cases, e.g. tests, require start/stop Nim library component, which implies start/stop nim-chronos threads.
- Then, certain file descriptors are leaked upon consecutive Nim-library-component creation/destruction (nim-chronos thread start/stop.) For example, on unix-like systems, fds handled by selector are leaked.

### Changes

- Attend and complete in-flight work requests to the chronos thread.
- nim-chronos thread blocks further tasks when shutdown is in progress.
- Free all resources, on each platform, when all tasks are completed.

### Context

The issue has been detected while testing [nim-sds](https://github.com/logos-messaging/nim-sds) in [status-go](https://github.com/status-im/status-go)

[This status-go PR](https://github.com/status-im/status-go/pull/7227) contains better issue detail.
[This](https://github.com/logos-messaging/nim-sds/pull/40) temporary workaround was implemented.

