### PR TITLE
chore(AsyncSemaphore): expose size as read only

### DIFF
--- a/chronos/asyncsync.nim
+++ b/chronos/asyncsync.nim
@@ -656,6 +656,9 @@ proc newAsyncSemaphore*(size: int = 1): AsyncSemaphore =
     waiters: initDeque[Future[void].Raising([CancelledError])](),
   )
 
+proc size*(s: AsyncSemaphore): int =
+  return s.size
+
 proc availableSlots*(s: AsyncSemaphore): int =
   return s.availableSlots
 

--- a/tests/testasyncsemaphore.nim
+++ b/tests/testasyncsemaphore.nim
@@ -14,20 +14,21 @@ suite "AsyncSemaphore":
   teardown:
     checkLeaks()
 
-  asyncTest "default size":
+  asyncTest "create default size":
     let sema = newAsyncSemaphore()
     check sema.availableSlots == 1
 
-  asyncTest "custom size":
+  asyncTest "create custom size":
     let sema = newAsyncSemaphore(3)
     check sema.availableSlots == 3
 
-  asyncTest "invalid size":
+  asyncTest "create invalid size":
     expect AssertionDefect:
       discard newAsyncSemaphore(0)
 
   asyncTest "should acquire":
     let sema = newAsyncSemaphore(3)
+    check sema.size() == 3
 
     await sema.acquire()
     check sema.availableSlots == 2
@@ -35,6 +36,8 @@ suite "AsyncSemaphore":
     check sema.availableSlots == 1
     await sema.acquire()
     check sema.availableSlots == 0
+    
+    check sema.size() == 3 # size is unchanged
 
   asyncTest "should release":
     let sema = newAsyncSemaphore(3)


### PR DESCRIPTION
logos messaging needs to access size of semaphore in two places, having getter for size makes it convenient. 

logos semaphote usage:
https://github.com/logos-messaging/logos-messaging-nim/blob/a4e44dbe05347197ba367f967aa99078814a80fc/waku/node/peer_manager/peer_manager.nim#L751
https://github.com/logos-messaging/logos-messaging-nim/blob/a4e44dbe05347197ba367f967aa99078814a80fc/waku/node/peer_manager/peer_manager.nim#L1053