### PR TITLE
CI: Doc: Replace actions-rs/install with cargo-bins/cargo-binstall.

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -18,26 +18,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: mdbook
-          use-tool-cache: true
-          version: "0.4.36"
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: mdbook-toc
-          use-tool-cache: true
-          version: "0.14.1"
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: mdbook-open-on-gh
-          use-tool-cache: true
-          version: "2.4.1"
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: mdbook-admonish
-          use-tool-cache: true
-          version: "1.14.0"
+
+      - name: Setup cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install mdBook and preprocessors
+        run: |
+          cargo binstall mdbook@0.4.36 \
+            mdbook-toc@0.14.1 \
+            mdbook-open-on-gh@2.4.1 \
+            mdbook-admonish@1.14.0
 
       - uses: jiro4989/setup-nim-action@v1
         with:


### PR DESCRIPTION
In [intops](https://github.com/vacp2p/nim-intops), switching from actions-rs/install to cargo-bins/cargo-binstall resulted in the docs build time improvement from [6 minutes](https://github.com/vacp2p/nim-intops/actions/runs/20863806433) to [16 seconds](https://github.com/vacp2p/nim-intops/actions/runs/20898947677) with the same mdBook preprocessors.

Hopefully, this change will also help the Chronos docs build faster (current build times are about [8 mins](https://github.com/status-im/nim-chronos/actions/workflows/doc.yml)).