### PR TITLE
Generate unique symbol for returned Future in async macro.

### DIFF
--- a/chronos/internal/asyncmacro.nim
+++ b/chronos/internal/asyncmacro.nim
@@ -488,7 +488,7 @@ proc asyncSingleProc(prc, params: NimNode): NimNode {.compileTime.} =
     outerProcBody.add(closureIterator)
 
     let
-      retFutureSym = ident "resultFuture"
+      retFutureSym = genSym(nskLet, "resultFuture")
       newFutProc = if raises == nil:
         nnkBracketExpr.newTree(ident "newFuture", baseType)
       else:


### PR DESCRIPTION
Attempt to fix https://github.com/nim-lang/langserver/issues/381

While researching the issue above, after debugging langserver and nimsuggest, I've noticed that it is only reproduced with Chronos's async macro, specifically because the transformed function is detected as an `nskLet` symbol `resultFuture`.

So I assumed the root of the problem should be within the Chronos's `async` macro implementation. I've ended up comparing asyncdispatch's `async` macro implementation with Chronos's one. I noticed the Chronos constructs the `Future` returned from the transformed function with `ident` while asyncdispatch uses `genSym`. `genSym` guarantees the created symbol is unique while `ident` injects a hardcoded identifier.

I'm not sure why that affects the way nimsuggest detects the symbol (in both cases the `Future` is defined inside the proc scope and shouldn't be a global scope `let` symbol). However, replacing `ident` with `genSym` solves the issue with the incorrect inlayHint improving DX for the developers using Chronos. Also, using `genSym` seems to be the preferred way of introducing symbols as this method (unlike `ident`) is hygienic.

Thus, this PR.