### PR TITLE
Bump bearssl to 0.2.7

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -10,7 +10,7 @@ skipDirs      = @["tests"]
 requires "nim >= 1.6.16",
          "results",
          "stew",
-         "bearssl >= 0.2.5",
+         "bearssl >= 0.2.7",
          "httputils",
          "unittest2"
 

--- a/chronos/streams/tlsstream.nim
+++ b/chronos/streams/tlsstream.nim
@@ -703,7 +703,7 @@ proc pemDecode*(data: openArray[char]): seq[PEMElement] {.
   var pctx = new PEMContext
   var res = newSeq[PEMElement]()
 
-  proc itemAppend(ctx: pointer, pbytes: pointer, nbytes: uint) {.cdecl.} =
+  proc itemAppend(ctx: pointer, pbytes: pointer, nbytes: csize_t) {.cdecl.} =
     var p = cast[PEMContext](ctx)
     var o = uint(len(p.data))
     p.data.setLen(o + nbytes)


### PR DESCRIPTION
`nim-bearssl` signature for `pemDecoderSetdest` was updated to `csize_t` to avoid issues with Clang 15:

- https://github.com/status-im/nim-bearssl/pull/69

Update to the correct callback proc type to remain compatible:

- https://github.com/nim-lang/Nim/issues/25617