### PR TITLE
Introduce vtable-based async stream implementation

### DIFF
--- a/chronos/bipbuffer.nim
+++ b/chronos/bipbuffer.nim
@@ -149,3 +149,64 @@ proc copyInto*(bp: var BipBuffer, tgt: var openArray[byte]): Natural =
   for (region, rsize) in bp.regions():
     n += tgt.toOpenArray(n, tgt.high()).copyFrom(region.makeOpenArray(rsize))
   n
+
+proc copyUntil*[T: byte|char](
+    bp: BipBuffer, tgt: var openArray[T], state: var int, sep: openArray[T]
+): tuple[n: Natural, found: bool] =
+  ## Bulk-copies the available bytes
+  var
+    n = Natural(0)
+    found = false
+
+  for ch in bp:
+    tgt[n] = T(ch)
+    n += 1
+
+    if sep.len == 0:
+      found = true
+      break
+
+    if T(ch) == sep[state]:
+      state += 1
+    else:
+      state = 0
+
+    if state == sep.len:
+      found = true
+      break
+
+    if n == tgt.len:
+      break
+
+  (n, found)
+
+proc addLineInto*(
+    bp: BipBuffer, tgt: var string, state: var int, limit: int, sep: openArray[char]
+): tuple[n: Natural, done: bool] =
+  ## Add bytes from buffer until sep found, limit is hit or buffer ends - sep is
+  ## removed from the tgt if found.
+  var
+    n = Natural(0)
+    done = false
+
+  for ch in bp:
+    tgt.add char(ch)
+    n += 1
+
+    if sep.len == 0:
+      done = true
+      break
+
+    if char(ch) == sep[state]:
+      state += 1
+
+    if state == sep.len:
+      tgt.setLen(tgt.len - sep.len)
+      done = true
+      break
+
+    if limit > 0 and tgt.len == limit:
+      done = true
+      break
+
+  (n, done)

--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -7,7 +7,7 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import std/strutils
 import stew/[ptrops, shims/sequninit]
@@ -26,6 +26,57 @@ const
     ## AsyncStreamWriter leaks tracker name
 
 type
+  AsyncStreamReaderVtbl* = object
+    atEof*: proc(rstream: AsyncStreamReader): bool {.gcsafe, raises: [].}
+    stopped*: proc(rstream: AsyncStreamReader): bool {.gcsafe, raises: [].}
+    running*: proc(rstream: AsyncStreamReader): bool {.gcsafe, raises: [].}
+    failed*: proc(rstream: AsyncStreamReader): bool {.gcsafe, raises: [].}
+    readExactly*: proc(rstream: AsyncStreamReader, pbytes: pointer, nbytes: int) {.
+      async: (raises: [CancelledError, AsyncStreamError])
+    .}
+    readOnce*: proc(
+      rstream: AsyncStreamReader, pbytes: pointer, nbytes: int
+    ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).}
+    readUntil*: proc(
+      rstream: AsyncStreamReader, pbytes: pointer, nbytes: int, sep: seq[byte]
+    ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).}
+    readLine*: proc(rstream: AsyncStreamReader, limit = 0, sep = "\r\n"): Future[string] {.
+      async: (raises: [CancelledError, AsyncStreamError])
+    .}
+    read*: proc(rstream: AsyncStreamReader): Future[seq[byte]] {.
+      async: (raises: [CancelledError, AsyncStreamError])
+    .}
+    readN*: proc(rstream: AsyncStreamReader, n: int): Future[seq[byte]] {.
+      async: (raises: [CancelledError, AsyncStreamError])
+    .}
+    consume*: proc(rstream: AsyncStreamReader): Future[int] {.
+      async: (raises: [CancelledError, AsyncStreamError])
+    .}
+    consumeN*: proc(rstream: AsyncStreamReader, n: int): Future[int] {.
+      async: (raises: [CancelledError, AsyncStreamError])
+    .}
+    readMessage*: proc(rstream: AsyncStreamReader, pred: ReadMessagePredicate) {.
+      async: (raises: [CancelledError, AsyncStreamError])
+    .}
+
+  AsyncStreamWriterVtbl* = object
+    atEof*: proc(wstream: AsyncStreamWriter): bool {.gcsafe, raises: [].}
+    stopped*: proc(wstream: AsyncStreamWriter): bool {.gcsafe, raises: [].}
+    running*: proc(wstream: AsyncStreamWriter): bool {.gcsafe, raises: [].}
+    failed*: proc(wstream: AsyncStreamWriter): bool {.gcsafe, raises: [].}
+    writePointer*: proc(wstream: AsyncStreamWriter, pbytes: pointer, nbytes: int) {.
+      async: (raises: [CancelledError, AsyncStreamError])
+    .}
+    writeSeq*: proc(wstream: AsyncStreamWriter, sbytes: seq[byte], msglen: int) {.
+      async: (raises: [CancelledError, AsyncStreamError])
+    .}
+    writeStr*: proc(wstream: AsyncStreamWriter, sbytes: string, msglen: int) {.
+      async: (raises: [CancelledError, AsyncStreamError])
+    .}
+    finish*: proc(wstream: AsyncStreamWriter) {.
+      async: (raises: [CancelledError, AsyncStreamError])
+    .}
+
   AsyncStreamError* = object of AsyncError
   AsyncStreamIncorrectDefect* = object of Defect
   AsyncStreamIncompleteError* = object of AsyncStreamError
@@ -72,26 +123,28 @@ type
     ## Main write loop for write streams.
 
   AsyncStreamReader* = ref object of RootRef
-    rsource*: AsyncStreamReader
-    tsource*: StreamTransport
-    readerLoop*: StreamReaderLoop
-    state*: AsyncStreamState
-    buffer*: AsyncBufferRef
-    udata: pointer
-    error*: ref AsyncStreamError
-    bytesCount*: uint64
-    future: Future[void].Raising([])
+    vtbl*: AsyncStreamReaderVtbl
+    rsource* {.deprecated.}: AsyncStreamReader
+    tsource* {.deprecated.}: StreamTransport
+    readerLoop* {.deprecated.}: StreamReaderLoop
+    state* {.deprecated.}: AsyncStreamState
+    buffer* {.deprecated.}: AsyncBufferRef
+    udata {.deprecated.}: pointer
+    error* {.deprecated.}: ref AsyncStreamError
+    bytesCount* {.deprecated.}: uint64
+    future {.deprecated.}: Future[void].Raising([])
 
   AsyncStreamWriter* = ref object of RootRef
-    wsource*: AsyncStreamWriter
-    tsource*: StreamTransport
-    writerLoop*: StreamWriterLoop
-    state*: AsyncStreamState
-    queue*: AsyncQueue[WriteItem]
-    error*: ref AsyncStreamError
-    udata: pointer
-    bytesCount*: uint64
-    future: Future[void].Raising([])
+    vtbl*: AsyncStreamWriterVtbl
+    wsource* {.deprecated.}: AsyncStreamWriter
+    tsource* {.deprecated.}: StreamTransport
+    writerLoop* {.deprecated.}: StreamWriterLoop
+    state* {.deprecated.}: AsyncStreamState
+    queue* {.deprecated.}: AsyncQueue[WriteItem]
+    error* {.deprecated.}: ref AsyncStreamError
+    udata {.deprecated.}: pointer
+    bytesCount* {.deprecated.}: uint64
+    future {.deprecated.}: Future[void].Raising([])
 
   AsyncStream* = object of RootObj
     reader*: AsyncStreamReader
@@ -205,29 +258,11 @@ proc raiseAsyncStreamWriteEOFError*() {.
 proc atEof*(rstream: AsyncStreamReader): bool =
   ## Returns ``true`` is reading stream is closed or finished and internal
   ## buffer do not have any bytes left.
-  if isNil(rstream.readerLoop):
-    if isNil(rstream.rsource):
-      rstream.tsource.atEof()
-    else:
-      rstream.rsource.atEof()
-  else:
-    (rstream.state != AsyncStreamState.Running) and
-      (len(rstream.buffer.backend) == 0)
+  rstream.vtbl.atEof(rstream)
 
 proc atEof*(wstream: AsyncStreamWriter): bool =
   ## Returns ``true`` is writing stream ``wstream`` closed or finished.
-  if isNil(wstream.writerLoop):
-    if isNil(wstream.wsource):
-      wstream.tsource.atEof()
-    else:
-      wstream.wsource.atEof()
-  else:
-    # `wstream.future` holds `rstream.writerLoop()` call's result.
-    # Return `true` if `writerLoop()` is not yet started or already stopped.
-    if isNil(wstream.future) or wstream.future.finished():
-      true
-    else:
-      wstream.state != AsyncStreamState.Running
+  wstream.vtbl.atEof(wstream)
 
 proc closed*(rw: AsyncStreamRW): bool =
   ## Returns ``true`` is reading/writing stream is closed.
@@ -237,63 +272,38 @@ proc finished*(rw: AsyncStreamRW): bool =
   ## Returns ``true`` if reading/writing stream is finished (completed).
   rw.atEof() and rw.state == AsyncStreamState.Finished
 
-proc stopped*(rw: AsyncStreamRW): bool =
+proc stopped*(wstream: AsyncStreamWriter): bool =
   ## Returns ``true`` if reading/writing stream is stopped (interrupted).
-  let loopIsNil =
-    when rw is AsyncStreamReader:
-      isNil(rw.readerLoop)
-    else:
-      isNil(rw.writerLoop)
+  wstream.vtbl.stopped(wstream)
 
-  if loopIsNil:
-    when rw is AsyncStreamReader:
-      if isNil(rw.rsource): false else: rw.rsource.stopped()
-    else:
-      if isNil(rw.wsource): false else: rw.wsource.stopped()
-  else:
-    if isNil(rw.future) or rw.future.finished():
-      false
-    else:
-      rw.state == AsyncStreamState.Stopped
+proc stopped*(rstream: AsyncStreamReader): bool =
+  ## Returns ``true`` if reading/writing stream is stopped (interrupted).
+  rstream.vtbl.stopped(rstream)
 
-proc running*(rw: AsyncStreamRW): bool =
+proc running*(rw: AsyncStreamWriter): bool =
   ## Returns ``true`` if reading/writing stream is still pending.
-  let loopIsNil =
-    when rw is AsyncStreamReader:
-      isNil(rw.readerLoop)
-    else:
-      isNil(rw.writerLoop)
-  if loopIsNil:
-    when rw is AsyncStreamReader:
-      if isNil(rw.rsource): rw.tsource.running() else: rw.rsource.running()
-    else:
-      if isNil(rw.wsource): rw.tsource.running() else: rw.wsource.running()
-  else:
-    if isNil(rw.future) or rw.future.finished():
-      false
-    else:
-      rw.state == AsyncStreamState.Running
+  rw.vtbl.running(rw)
 
-proc failed*(rw: AsyncStreamRW): bool =
+proc running*(rstream: AsyncStreamReader): bool =
+  ## Returns ``true`` if reading/writing stream is still pending.
+  rstream.vtbl.running(rstream)
+
+proc failed*(rw: AsyncStreamWriter): bool =
   ## Returns ``true`` if reading/writing stream is in failed state.
-  let loopIsNil =
-    when rw is AsyncStreamReader:
-      isNil(rw.readerLoop)
-    else:
-      isNil(rw.writerLoop)
-  if loopIsNil:
-    when rw is AsyncStreamReader:
-      if isNil(rw.rsource): rw.tsource.failed() else: rw.rsource.failed()
-    else:
-      if isNil(rw.wsource): rw.tsource.failed() else: rw.wsource.failed()
-  else:
-    if isNil(rw.future) or rw.future.finished():
-      false
-    else:
-      rw.state == AsyncStreamState.Error
+  rw.vtbl.failed(rw)
+
+proc failed*(rstream: AsyncStreamReader): bool =
+  ## Returns ``true`` if reading/writing stream is in failed state.
+  rstream.vtbl.failed(rstream)
 
 template checkStreamClosed*(t: untyped) =
   if t.closed(): raiseAsyncStreamUseClosedError()
+
+template checkStreamClosed*(t: untyped, T: type) =
+  if t.closed():
+    var fut = newFuture[T]()
+    fut.fail(newAsyncStreamUseClosedError())
+    return fut
 
 template checkStreamFinished*(t: untyped) =
   if t.atEof(): raiseAsyncStreamWriteEOFError()
@@ -310,12 +320,12 @@ template readLoop(body: untyped): untyped =
     if done:
       break
     else:
-      if not(rstream.atEof()):
+      if not (rstream.atEof()):
         await rstream.buffer.wait()
 
 proc readExactly*(rstream: AsyncStreamReader, pbytes: pointer,
                   nbytes: int) {.
-     async: (raises: [CancelledError, AsyncStreamError]).} =
+     async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
   ## Read exactly ``nbytes`` bytes from read-only stream ``rstream`` and store
   ## it to ``pbytes``.
   ##
@@ -324,69 +334,32 @@ proc readExactly*(rstream: AsyncStreamReader, pbytes: pointer,
   doAssert(not(isNil(pbytes)), "pbytes must not be nil")
   doAssert(nbytes >= 0, "nbytes must be non-negative integer")
 
-  checkStreamClosed(rstream)
+  checkStreamClosed(rstream, void)
 
   if nbytes == 0:
-    return
+    let fut = newFuture[void]()
+    fut.complete()
+    return fut
 
-  if isNil(rstream.rsource):
-    try:
-      await readExactly(rstream.tsource, pbytes, nbytes)
-    except TransportIncompleteError:
-      raise newAsyncStreamIncompleteError()
-    except TransportError as exc:
-      raise newAsyncStreamReadError(exc)
-  else:
-    if isNil(rstream.readerLoop):
-      await readExactly(rstream.rsource, pbytes, nbytes)
-    else:
-      var
-        total = 0
-        pbuffer = cast[ptr byte](pbytes)
-      readLoop():
-        if len(rstream.buffer.backend) == 0:
-          if rstream.atEof():
-            raise newAsyncStreamIncompleteError()
-        let consumed =
-          rstream.buffer.backend.copyInto(pbuffer.makeOpenArray(nbytes - total))
-        pbuffer = pbuffer.offset(consumed)
-        total += consumed
-        (consumed: consumed, done: total == nbytes)
+  rstream.vtbl.readExactly(rstream, pbytes, nbytes)
 
 proc readOnce*(rstream: AsyncStreamReader, pbytes: pointer,
                nbytes: int): Future[int] {.
-     async: (raises: [CancelledError, AsyncStreamError]).} =
+     async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
   ## Perform one read operation on read-only stream ``rstream``.
   ##
   ## If internal buffer is not empty, ``nbytes`` bytes will be transferred from
   ## internal buffer, otherwise it will wait until some bytes will be available.
   doAssert(not(isNil(pbytes)), "pbytes must not be nil")
   doAssert(nbytes > 0, "nbytes must be positive value")
-  checkStreamClosed(rstream)
 
-  if isNil(rstream.rsource):
-    try:
-      return await readOnce(rstream.tsource, pbytes, nbytes)
-    except TransportError as exc:
-      raise newAsyncStreamReadError(exc)
-  else:
-    if isNil(rstream.readerLoop):
-      return await readOnce(rstream.rsource, pbytes, nbytes)
-    else:
-      var
-        total = 0
-        pbuffer = cast[ptr byte](pbytes)
-      readLoop():
-        if len(rstream.buffer.backend) == 0:
-          (0, rstream.atEof())
-        else:
-          total = rstream.buffer.backend.copyInto(pbuffer.makeOpenArray(nbytes))
-          (total, true)
-      total
+  checkStreamClosed(rstream, int)
+
+  rstream.vtbl.readOnce(rstream, pbytes, nbytes)
 
 proc readUntil*(rstream: AsyncStreamReader, pbytes: pointer, nbytes: int,
                 sep: seq[byte]): Future[int] {.
-     async: (raises: [CancelledError, AsyncStreamError]).} =
+     async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
   ## Read data from the read-only stream ``rstream`` until separator ``sep`` is
   ## found.
   ##
@@ -403,54 +376,19 @@ proc readUntil*(rstream: AsyncStreamReader, pbytes: pointer, nbytes: int,
   doAssert(not(isNil(pbytes)), "pbytes must not be nil")
   doAssert(len(sep) > 0, "separator must not be empty")
   doAssert(nbytes >= 0, "nbytes must be non-negative value")
-  checkStreamClosed(rstream)
+
+  checkStreamClosed(rstream, int)
 
   if nbytes == 0:
-    raise newAsyncStreamLimitError()
+    var fut = newFuture[int]()
+    fut.fail(newAsyncStreamLimitError())
+    return fut
 
-  if isNil(rstream.rsource):
-    try:
-      return await readUntil(rstream.tsource, pbytes, nbytes, sep)
-    except TransportIncompleteError:
-      raise newAsyncStreamIncompleteError()
-    except TransportLimitError:
-      raise newAsyncStreamLimitError()
-    except TransportError as exc:
-      raise newAsyncStreamReadError(exc)
-  else:
-    if isNil(rstream.readerLoop):
-      return await readUntil(rstream.rsource, pbytes, nbytes, sep)
-    else:
-      var
-        pbuffer = pbytes.toUnchecked()
-        state = 0
-        k = 0
-      readLoop():
-        if rstream.atEof():
-          raise newAsyncStreamIncompleteError()
-
-        var index = 0
-        for ch in rstream.buffer.backend:
-          if k >= nbytes:
-            raise newAsyncStreamLimitError()
-
-          inc(index)
-          pbuffer[k] = ch
-          inc(k)
-
-          if sep[state] == ch:
-            inc(state)
-            if state == len(sep):
-              break
-          else:
-            state = 0
-
-        (index, state == len(sep))
-      k
+  rstream.vtbl.readUntil(rstream, pbytes, nbytes, sep)
 
 proc readLine*(rstream: AsyncStreamReader, limit = 0,
                sep = "\r\n"): Future[string] {.
-     async: (raises: [CancelledError, AsyncStreamError]).} =
+     async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
   ## Read one line from read-only stream ``rstream``, where ``"line"`` is a
   ## sequence of bytes ending with ``sep`` (default is ``"\r\n"``).
   ##
@@ -462,165 +400,50 @@ proc readLine*(rstream: AsyncStreamReader, limit = 0,
   ##
   ## If ``limit`` more then 0, then result string will be limited to ``limit``
   ## bytes.
-  checkStreamClosed(rstream)
+  checkStreamClosed(rstream, string)
 
-  if isNil(rstream.rsource):
-    try:
-      return await readLine(rstream.tsource, limit, sep)
-    except TransportError as exc:
-      raise newAsyncStreamReadError(exc)
-  else:
-    if isNil(rstream.readerLoop):
-      return await readLine(rstream.rsource, limit, sep)
-    else:
-      var res = ""
-
-      readLoop():
-        if rstream.atEof():
-          (0, true)
-        else:
-          var
-            consumed = 0
-            done = false
-          for ch in rstream.buffer.backend:
-            res.add char(ch)
-            consumed += 1
-
-            if res.endsWith(sep):
-              res.setLen(res.len - sep.len)
-              done = true
-              break
-
-            if limit > 0 and res.len == limit:
-              done = true
-              break
-
-          (consumed, done)
-      res
+  rstream.vtbl.readLine(rstream, limit, sep)
 
 proc read*(rstream: AsyncStreamReader): Future[seq[byte]] {.
-     async: (raises: [CancelledError, AsyncStreamError]).} =
+     async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
   ## Read all bytes from read-only stream ``rstream``.
   ##
   ## This procedure allocates buffer seq[byte] and return it as result.
-  checkStreamClosed(rstream)
+  checkStreamClosed(rstream, seq[byte])
 
-  if isNil(rstream.rsource):
-    try:
-      return await read(rstream.tsource)
-    except TransportLimitError:
-      raise newAsyncStreamLimitError()
-    except TransportError as exc:
-      raise newAsyncStreamReadError(exc)
-  else:
-    if isNil(rstream.readerLoop):
-      return await read(rstream.rsource)
-    else:
-      var res: seq[byte]
-      readLoop():
-        if rstream.atEof():
-          (0, true)
-        else:
-          var pos = res.len
-          res.setLenUninit(pos + rstream.buffer.backend.len())
-          let bytesRead =
-            rstream.buffer.backend.copyInto(res.toOpenArray(pos, res.high()))
-          (bytesRead, false)
-      res
+  rstream.vtbl.read(rstream)
 
 proc read*(rstream: AsyncStreamReader, n: int): Future[seq[byte]] {.
-     async: (raises: [CancelledError, AsyncStreamError]).} =
+     async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
   ## Read all bytes (n <= 0) or exactly `n` bytes from read-only stream
   ## ``rstream``.
   ##
   ## This procedure allocates buffer seq[byte] and return it as result.
-  checkStreamClosed(rstream)
+  checkStreamClosed(rstream, seq[byte])
 
-  if isNil(rstream.rsource):
-    try:
-      return await read(rstream.tsource, n)
-    except TransportError as exc:
-      raise newAsyncStreamReadError(exc)
-  else:
-    if isNil(rstream.readerLoop):
-      return await read(rstream.rsource, n)
-    else:
-      if n <= 0:
-        return await read(rstream.rsource)
-      else:
-        var res = newSeq[byte]()
-        readLoop():
-          if rstream.atEof():
-            (0, true)
-          else:
-            var pos = res.len
-            res.setLenUninit(pos + min(rstream.buffer.backend.len(), n - res.len))
-            let bytesRead =
-              rstream.buffer.backend.copyInto(res.toOpenArray(pos, res.high()))
-            (bytesRead, len(res) == n)
-        res
+  rstream.vtbl.readN(rstream, n)
 
 proc consume*(rstream: AsyncStreamReader): Future[int] {.
-     async: (raises: [CancelledError, AsyncStreamError]).} =
+     async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
   ## Consume (discard) all bytes from read-only stream ``rstream``.
   ##
   ## Return number of bytes actually consumed (discarded).
-  checkStreamClosed(rstream)
+  checkStreamClosed(rstream, int)
 
-  if isNil(rstream.rsource):
-    try:
-      return await consume(rstream.tsource)
-    except TransportLimitError:
-      raise newAsyncStreamLimitError()
-    except TransportError as exc:
-      raise newAsyncStreamReadError(exc)
-  else:
-    if isNil(rstream.readerLoop):
-      return await consume(rstream.rsource)
-    else:
-      var res = 0
-      readLoop():
-        if rstream.atEof():
-          (0, true)
-        else:
-          let used = len(rstream.buffer.backend)
-          res += used
-          (used, false)
-      res
+  rstream.vtbl.consume(rstream)
 
 proc consume*(rstream: AsyncStreamReader, n: int): Future[int] {.
-     async: (raises: [CancelledError, AsyncStreamError]).} =
+     async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
   ## Consume (discard) all bytes (n <= 0) or ``n`` bytes from read-only stream
   ## ``rstream``.
   ##
   ## Return number of bytes actually consumed (discarded).
-  checkStreamClosed(rstream)
+  checkStreamClosed(rstream, int)
 
-  if isNil(rstream.rsource):
-    try:
-      return await consume(rstream.tsource, n)
-    except TransportLimitError:
-      raise newAsyncStreamLimitError()
-    except TransportError as exc:
-      raise newAsyncStreamReadError(exc)
-  else:
-    if isNil(rstream.readerLoop):
-      return await consume(rstream.rsource, n)
-    else:
-      if n <= 0:
-        return await rstream.consume()
-      else:
-        var res = 0
-        readLoop():
-          let
-            used = len(rstream.buffer.backend)
-            count = min(used, n - res)
-          res += count
-          (count, res == n)
-        res
+  rstream.vtbl.consumeN(rstream, n)
 
 proc readMessage*(rstream: AsyncStreamReader, pred: ReadMessagePredicate) {.
-     async: (raises: [CancelledError, AsyncStreamError]).} =
+     async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
   ## Read all bytes from stream ``rstream`` until ``predicate`` callback
   ## will not be satisfied.
   ##
@@ -634,30 +457,9 @@ proc readMessage*(rstream: AsyncStreamReader, pred: ReadMessagePredicate) {.
   ## ``predicate`` callback will receive (zero-length) openArray, if stream
   ## is at EOF.
   doAssert(not(isNil(pred)), "`predicate` callback should not be `nil`")
-  checkStreamClosed(rstream)
+  checkStreamClosed(rstream, void)
 
-  if isNil(rstream.rsource):
-    try:
-      await readMessage(rstream.tsource, pred)
-    except TransportError as exc:
-      raise newAsyncStreamReadError(exc)
-  else:
-    if isNil(rstream.readerLoop):
-      await readMessage(rstream.rsource, pred)
-    else:
-      readLoop():
-        if len(rstream.buffer.backend) == 0:
-          if rstream.atEof():
-            pred([])
-          else:
-            # Case, when transport's buffer is not yet filled with data.
-            (0, false)
-        else:
-          var res: tuple[consumed: int, done: bool]
-          for (region, rsize) in rstream.buffer.backend.regions():
-            res = pred(region.toUnchecked().toOpenArray(0, rsize - 1))
-            break
-          res
+  rstream.vtbl.readMessage(rstream, pred)
 
 proc write*(wstream: AsyncStreamWriter, pbytes: pointer,
             nbytes: int) {.
@@ -672,27 +474,9 @@ proc write*(wstream: AsyncStreamWriter, pbytes: pointer,
   if nbytes <= 0:
     raiseEmptyMessageDefect()
 
-  if isNil(wstream.wsource):
-    var res: int
-    try:
-      res = await write(wstream.tsource, pbytes, nbytes)
-    except TransportError as exc:
-      raise newAsyncStreamWriteError(exc)
-    if res != nbytes:
-      raise newAsyncStreamIncompleteError()
-    wstream.bytesCount = wstream.bytesCount + uint64(nbytes)
-  else:
-    if isNil(wstream.writerLoop):
-      await write(wstream.wsource, pbytes, nbytes)
-      wstream.bytesCount = wstream.bytesCount + uint64(nbytes)
-    else:
-      let item = WriteItem(
-        kind: Pointer, dataPtr: pbytes, size: nbytes,
-        future: Future[void].Raising([CancelledError, AsyncStreamError])
-                  .init("async.stream.write(pointer)"))
-      await wstream.queue.put(item)
-      await item.future
-      wstream.bytesCount = wstream.bytesCount + uint64(item.size)
+  await wstream.vtbl.writePointer(wstream, pbytes, nbytes)
+
+  wstream.bytesCount += uint64(nbytes)
 
 proc write*(wstream: AsyncStreamWriter, sbytes: seq[byte],
             msglen = -1) {.
@@ -712,27 +496,9 @@ proc write*(wstream: AsyncStreamWriter, sbytes: seq[byte],
   if length <= 0:
     raiseEmptyMessageDefect()
 
-  if isNil(wstream.wsource):
-    var res: int
-    try:
-      res = await write(wstream.tsource, sbytes, length)
-    except TransportError as exc:
-      raise newAsyncStreamWriteError(exc)
-    if res != length:
-      raise newAsyncStreamIncompleteError()
-    wstream.bytesCount = wstream.bytesCount + uint64(length)
-  else:
-    if isNil(wstream.writerLoop):
-      await write(wstream.wsource, sbytes, length)
-      wstream.bytesCount = wstream.bytesCount + uint64(length)
-    else:
-      let item = WriteItem(
-        kind: Sequence, dataSeq: sbytes, size: length,
-        future: Future[void].Raising([CancelledError, AsyncStreamError])
-                  .init("async.stream.write(seq)"))
-      await wstream.queue.put(item)
-      await item.future
-      wstream.bytesCount = wstream.bytesCount + uint64(item.size)
+  await wstream.vtbl.writeSeq(wstream, sbytes, length)
+
+  wstream.bytesCount += uint64(length)
 
 proc write*(wstream: AsyncStreamWriter, sbytes: string,
             msglen = -1) {.
@@ -751,27 +517,8 @@ proc write*(wstream: AsyncStreamWriter, sbytes: string,
   if length <= 0:
     raiseEmptyMessageDefect()
 
-  if isNil(wstream.wsource):
-    var res: int
-    try:
-      res = await write(wstream.tsource, sbytes, length)
-    except TransportError as exc:
-      raise newAsyncStreamWriteError(exc)
-    if res != length:
-      raise newAsyncStreamIncompleteError()
-    wstream.bytesCount = wstream.bytesCount + uint64(length)
-  else:
-    if isNil(wstream.writerLoop):
-      await write(wstream.wsource, sbytes, length)
-      wstream.bytesCount = wstream.bytesCount + uint64(length)
-    else:
-      let item = WriteItem(
-        kind: String, dataStr: sbytes, size: length,
-        future: Future[void].Raising([CancelledError, AsyncStreamError])
-                  .init("async.stream.write(string)"))
-      await wstream.queue.put(item)
-      await item.future
-      wstream.bytesCount = wstream.bytesCount + uint64(item.size)
+  await wstream.vtbl.writeStr(wstream, sbytes, length)
+  wstream.bytesCount += uint64(length)
 
 proc finish*(wstream: AsyncStreamWriter) {.
      async: (raises: [CancelledError, AsyncStreamError]).} =
@@ -780,16 +527,7 @@ proc finish*(wstream: AsyncStreamWriter) {.
   # For AsyncStreamWriter Finished state could be set manually or by stream's
   # writeLoop, so we not going to raise exception here.
   if not(wstream.atEof()):
-    if not isNil(wstream.wsource):
-      if isNil(wstream.writerLoop):
-        await wstream.wsource.finish()
-      else:
-        let item = WriteItem(
-          kind: Pointer, size: 0,
-          future: Future[void].Raising([CancelledError, AsyncStreamError])
-                    .init("async.stream.finish"))
-        await wstream.queue.put(item)
-        await item.future
+    await wstream.vtbl.finish(wstream)
 
 proc join*(rw: AsyncStreamRW): Future[void] {.
      async: (raw: true, raises: [CancelledError]).} =
@@ -797,7 +535,7 @@ proc join*(rw: AsyncStreamRW): Future[void] {.
   ## closed.
   rw.future.join()
 
-proc close*(rw: AsyncStreamRW) =
+proc close*(rw: AsyncStreamReader) =
   ## Close and frees resources of stream ``rw``.
   ##
   ## Note close() procedure is not completed immediately!
@@ -809,30 +547,41 @@ proc close*(rw: AsyncStreamRW) =
         GC_unref(cast[ref int](rw.udata))
       if not(rw.future.finished()):
         rw.future.complete()
-      when rw is AsyncStreamReader:
-        untrackCounter(AsyncStreamReaderTrackerName)
-      elif rw is AsyncStreamWriter:
-        untrackCounter(AsyncStreamWriterTrackerName)
+      untrackCounter(AsyncStreamReaderTrackerName)
       rw.state = AsyncStreamState.Closed
 
-    when rw is AsyncStreamReader:
-      if isNil(rw.rsource) or isNil(rw.readerLoop) or isNil(rw.future):
+    if isNil(rw.rsource) or isNil(rw.readerLoop) or isNil(rw.future):
+      callSoon(continuation)
+    else:
+      if rw.future.finished():
         callSoon(continuation)
       else:
-        if rw.future.finished():
-          callSoon(continuation)
-        else:
-          rw.future.addCallback(continuation)
-          rw.future.cancelSoon()
-    elif rw is AsyncStreamWriter:
-      if isNil(rw.wsource) or isNil(rw.writerLoop) or isNil(rw.future):
+        rw.future.addCallback(continuation)
+        rw.future.cancelSoon()
+
+proc close*(rw: AsyncStreamWriter) =
+  ## Close and frees resources of stream ``rw``.
+  ##
+  ## Note close() procedure is not completed immediately!
+  if not(rw.closed()):
+    rw.state = AsyncStreamState.Closing
+
+    proc continuation(udata: pointer) {.raises: [].} =
+      if not isNil(rw.udata):
+        GC_unref(cast[ref int](rw.udata))
+      if not(rw.future.finished()):
+        rw.future.complete()
+      untrackCounter(AsyncStreamWriterTrackerName)
+      rw.state = AsyncStreamState.Closed
+
+    if isNil(rw.wsource) or isNil(rw.writerLoop) or isNil(rw.future):
+      callSoon(continuation)
+    else:
+      if rw.future.finished():
         callSoon(continuation)
       else:
-        if rw.future.finished():
-          callSoon(continuation)
-        else:
-          rw.future.addCallback(continuation)
-          rw.future.cancelSoon()
+        rw.future.addCallback(continuation)
+        rw.future.cancelSoon()
 
 proc closeWait*(rw: AsyncStreamRW): Future[void] {.async: (raises: []).} =
   ## Close and frees resources of stream ``rw``.
@@ -856,10 +605,591 @@ proc startWriter(wstream: AsyncStreamWriter) =
     wstream.future = Future[void].Raising([]).init(
       "async.stream.empty.writer", {FutureFlag.OwnCancelSchedule})
 
+proc init(T: type AsyncStreamReaderVtbl, rsource: AsyncStreamReader): T =
+  proc atEofImpl(rstream: AsyncStreamReader): bool =
+    rsource.atEof()
+
+  proc stoppedImpl(rstream: AsyncStreamReader): bool =
+    rsource.stopped()
+
+  proc runningImpl(rstream: AsyncStreamReader): bool =
+    rsource.running()
+
+  proc failedImpl(rstream: AsyncStreamReader): bool =
+    rsource.failed()
+
+  proc readExactlyImpl(
+      rstream: AsyncStreamReader, pbytes: pointer, nbytes: int
+  ) {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
+    readExactly(rsource, pbytes, nbytes)
+
+  proc readOnceImpl(
+      rstream: AsyncStreamReader, pbytes: pointer, nbytes: int
+  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
+    readOnce(rsource, pbytes, nbytes)
+
+  proc readUntilImpl(
+      rstream: AsyncStreamReader, pbytes: pointer, nbytes: int, sep: seq[byte]
+  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
+    readUntil(rsource, pbytes, nbytes, sep)
+
+  proc readLineImpl(
+      rstream: AsyncStreamReader, limit = 0, sep = "\r\n"
+  ): Future[string] {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
+    readLine(rsource, limit, sep)
+
+  proc readImpl(
+      rstream: AsyncStreamReader
+  ): Future[seq[byte]] {.
+      async: (raises: [CancelledError, AsyncStreamError], raw: true)
+  .} =
+    read(rsource)
+
+  proc readNImpl(
+      rstream: AsyncStreamReader, n: int
+  ): Future[seq[byte]] {.
+      async: (raises: [CancelledError, AsyncStreamError], raw: true)
+  .} =
+    read(rsource, n)
+
+  proc consumeImpl(
+      rstream: AsyncStreamReader
+  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
+    consume(rsource)
+
+  proc consumeNImpl(
+      rstream: AsyncStreamReader, n: int
+  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
+    consume(rsource, n)
+
+  proc readMessageImpl(
+      rstream: AsyncStreamReader, pred: ReadMessagePredicate
+  ) {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
+    readMessage(rsource, pred)
+
+  T(
+    atEof: atEofImpl,
+    stopped: stoppedImpl,
+    running: runningImpl,
+    failed: failedImpl,
+    readExactly: readExactlyImpl,
+    readOnce: readOnceImpl,
+    readUntil: readUntilImpl,
+    readLine: readLineImpl,
+    read: readImpl,
+    readN: readNImpl,
+    consume: consumeImpl,
+    consumeN: consumeNImpl,
+    readMessage: readMessageImpl,
+  )
+
+proc init(T: type AsyncStreamReaderVtbl, tsource: StreamTransport): T =
+  proc atEofImpl(rstream: AsyncStreamReader): bool =
+    tsource.atEof()
+
+  proc stoppedImpl(rstream: AsyncStreamReader): bool =
+    false
+
+  proc runningImpl(rstream: AsyncStreamReader): bool =
+    tsource.running()
+
+  proc failedImpl(rstream: AsyncStreamReader): bool =
+    tsource.failed()
+
+  proc readExactlyImpl(
+      rstream: AsyncStreamReader, pbytes: pointer, nbytes: int
+  ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    try:
+      await readExactly(tsource, pbytes, nbytes)
+    except TransportIncompleteError:
+      raise newAsyncStreamIncompleteError()
+    except TransportError as exc:
+      raise newAsyncStreamReadError(exc)
+
+  proc readOnceImpl(
+      rstream: AsyncStreamReader, pbytes: pointer, nbytes: int
+  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    try:
+      await readOnce(tsource, pbytes, nbytes)
+    except TransportError as exc:
+      raise newAsyncStreamReadError(exc)
+
+  proc readUntilImpl(
+      rstream: AsyncStreamReader, pbytes: pointer, nbytes: int, sep: seq[byte]
+  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    try:
+      await readUntil(tsource, pbytes, nbytes, sep)
+    except TransportIncompleteError:
+      raise newAsyncStreamIncompleteError()
+    except TransportLimitError:
+      raise newAsyncStreamLimitError()
+    except TransportError as exc:
+      raise newAsyncStreamReadError(exc)
+
+  proc readLineImpl(
+      rstream: AsyncStreamReader, limit = 0, sep = "\r\n"
+  ): Future[string] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    try:
+      return await readLine(tsource, limit, sep)
+    except TransportError as exc:
+      raise newAsyncStreamReadError(exc)
+
+  proc readImpl(
+      rstream: AsyncStreamReader
+  ): Future[seq[byte]] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    try:
+      return await read(tsource)
+    except TransportLimitError:
+      raise newAsyncStreamLimitError()
+    except TransportError as exc:
+      raise newAsyncStreamReadError(exc)
+
+  proc readNImpl(
+      rstream: AsyncStreamReader, n: int
+  ): Future[seq[byte]] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    try:
+      return await read(tsource, n)
+    except TransportError as exc:
+      raise newAsyncStreamReadError(exc)
+
+  proc consumeImpl(
+      rstream: AsyncStreamReader
+  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    try:
+      return await consume(tsource)
+    except TransportLimitError:
+      raise newAsyncStreamLimitError()
+    except TransportError as exc:
+      raise newAsyncStreamReadError(exc)
+
+  proc consumeNImpl(
+      rstream: AsyncStreamReader, n: int
+  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    try:
+      return await consume(tsource, n)
+    except TransportLimitError:
+      raise newAsyncStreamLimitError()
+    except TransportError as exc:
+      raise newAsyncStreamReadError(exc)
+
+  proc readMessageImpl(
+      rstream: AsyncStreamReader, pred: ReadMessagePredicate
+  ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    try:
+      await readMessage(tsource, pred)
+    except TransportError as exc:
+      raise newAsyncStreamReadError(exc)
+
+  T(
+    atEof: atEofImpl,
+    stopped: stoppedImpl,
+    running: runningImpl,
+    failed: failedImpl,
+    readExactly: readExactlyImpl,
+    readOnce: readOnceImpl,
+    readUntil: readUntilImpl,
+    readLine: readLineImpl,
+    read: readImpl,
+    readN: readNImpl,
+    consume: consumeImpl,
+    consumeN: consumeNImpl,
+    readMessage: readMessageImpl,
+  )
+
+proc init(
+    T: type AsyncStreamReaderVtbl,
+    rstream: AsyncStreamReader,
+    readerLoop: StreamReaderLoop,
+): T =
+  proc atEofImpl(rstream: AsyncStreamReader): bool =
+    (rstream.state != AsyncStreamState.Running) and (len(rstream.buffer.backend) == 0)
+
+  proc stoppedImpl(rstream: AsyncStreamReader): bool =
+    if isNil(rstream.future) or rstream.future.finished():
+      false
+    else:
+      rstream.state == AsyncStreamState.Stopped
+
+  proc runningImpl(rstream: AsyncStreamReader): bool =
+    if isNil(rstream.future) or rstream.future.finished():
+      false
+    else:
+      rstream.state == AsyncStreamState.Running
+
+  proc failedImpl(rstream: AsyncStreamReader): bool =
+    if isNil(rstream.future) or rstream.future.finished():
+      false
+    else:
+      rstream.state == AsyncStreamState.Error
+
+  proc readExactlyImpl(
+      rstream: AsyncStreamReader, pbytes: pointer, nbytes: int
+  ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
+      var
+        total = 0
+        pbuffer = cast[ptr byte](pbytes)
+      readLoop():
+        if len(rstream.buffer.backend) == 0:
+          if rstream.atEof():
+            raise newAsyncStreamIncompleteError()
+        let consumed =
+          rstream.buffer.backend.copyInto(pbuffer.makeOpenArray(nbytes - total))
+        pbuffer = pbuffer.offset(consumed)
+        total += consumed
+        (consumed: consumed, done: total == nbytes)
+
+  proc readOnceImpl(
+      rstream: AsyncStreamReader, pbytes: pointer, nbytes: int
+  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+      var
+        total = 0
+        pbuffer = cast[ptr byte](pbytes)
+      readLoop():
+        if len(rstream.buffer.backend) == 0:
+          (0, rstream.atEof())
+        else:
+          total = rstream.buffer.backend.copyInto(pbuffer.makeOpenArray(nbytes))
+          (total, true)
+      total
+
+  proc readUntilImpl(
+      rstream: AsyncStreamReader, pbytes: pointer, nbytes: int, sep: seq[byte]
+  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    var
+      pbuffer = pbytes.toUnchecked()
+      state = 0
+      k = 0
+    readLoop:
+      if rstream.atEof():
+        raise newAsyncStreamIncompleteError()
+
+      if k == nbytes:
+        raise newAsyncStreamLimitError()
+
+      let (n, found) = rstream.buffer.backend.copyUntil(
+        pbuffer.toOpenArray(k, nbytes - 1), state, sep)
+      k += n
+
+      (n, found)
+
+    k
+
+  proc readLineImpl(
+      rstream: AsyncStreamReader, limit = 0, sep = "\r\n"
+  ): Future[string] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    var
+      res = ""
+      state = 0
+
+    readLoop():
+      if rstream.atEof():
+        (0, true)
+      else:
+        rstream.buffer.backend.addLineInto(res, state, limit, sep)
+
+    res
+
+  proc readImpl(
+      rstream: AsyncStreamReader
+  ): Future[seq[byte]] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    var res: seq[byte]
+    readLoop():
+      if rstream.atEof():
+        (0, true)
+      else:
+        var pos = res.len
+        res.setLenUninit(pos + rstream.buffer.backend.len())
+        let bytesRead =
+          rstream.buffer.backend.copyInto(res.toOpenArray(pos, res.high()))
+        (bytesRead, false)
+    res
+
+  proc readNImpl(
+      rstream: AsyncStreamReader, n: int
+  ): Future[seq[byte]] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    var res = newSeq[byte]()
+    readLoop():
+      if rstream.atEof():
+        (0, true)
+      else:
+        var pos = res.len
+        res.setLenUninit(pos + min(rstream.buffer.backend.len(), n - res.len))
+        let bytesRead =
+          rstream.buffer.backend.copyInto(res.toOpenArray(pos, res.high()))
+        (bytesRead, len(res) == n)
+    res
+
+  proc consumeImpl(
+      rstream: AsyncStreamReader
+  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    var res = 0
+    readLoop:
+      if rstream.atEof():
+        (0, true)
+      else:
+        let used = len(rstream.buffer.backend)
+        res += used
+        (used, false)
+    res
+
+  proc consumeNImpl(
+      rstream: AsyncStreamReader, n: int
+  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    if n <= 0:
+      return await rstream.consume()
+    else:
+      var res = 0
+      readLoop:
+        let
+          used = len(rstream.buffer.backend)
+          count = min(used, n - res)
+        res += count
+        (count, res == n)
+      res
+
+  proc readMessageImpl(
+      rstream: AsyncStreamReader, pred: ReadMessagePredicate
+  ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    readLoop:
+      if len(rstream.buffer.backend) == 0:
+        if rstream.atEof():
+          pred([])
+        else:
+          # Case, when transport's buffer is not yet filled with data.
+          (0, false)
+      else:
+        var res: tuple[consumed: int, done: bool]
+        for (region, rsize) in rstream.buffer.backend.regions():
+          res = pred(region.toUnchecked().toOpenArray(0, rsize - 1))
+          break
+        res
+
+  T(
+    atEof: atEofImpl,
+    stopped: stoppedImpl,
+    running: runningImpl,
+    failed: failedImpl,
+    readExactly: readExactlyImpl,
+    readOnce: readOnceImpl,
+    readUntil: readUntilImpl,
+    readLine: readLineImpl,
+    read: readImpl,
+    readN: readNImpl,
+    consume: consumeImpl,
+    consumeN: consumeNImpl,
+    readMessage: readMessageImpl,
+  )
+
+proc init(T: type AsyncStreamWriterVtbl, wsource: AsyncStreamWriter): T =
+  proc atEofImpl(wstream: AsyncStreamWriter): bool =
+    wsource.atEof()
+
+  proc stoppedImpl(rw: AsyncStreamWriter): bool =
+    wsource.stopped()
+
+  proc runningImpl(rw: AsyncStreamWriter): bool =
+    ## Returns ``true`` if reading/writing stream is still pending.
+    wsource.running()
+
+  proc failedImpl(rw: AsyncStreamWriter): bool =
+    ## Returns ``true`` if reading/writing stream is in failed state.
+    wsource.failed()
+
+  proc writeImpl(
+      wstream: AsyncStreamWriter, pbytes: pointer, nbytes: int
+  ) {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
+    write(wsource, pbytes, nbytes)
+
+  proc writeImpl(
+      wstream: AsyncStreamWriter, sbytes: seq[byte], length: int
+  ) {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
+    write(wsource, sbytes, length)
+
+  proc writeImpl(
+      wstream: AsyncStreamWriter, sbytes: string, length: int
+  ) {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
+    write(wsource, sbytes, length)
+
+  proc finishImpl(
+      wstream: AsyncStreamWriter
+  ) {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
+    wsource.finish()
+
+  AsyncStreamWriterVtbl(
+    atEof: atEofImpl,
+    stopped: stoppedImpl,
+    running: runningImpl,
+    failed: failedImpl,
+    writePointer: writeImpl,
+    writeSeq: writeImpl,
+    writeStr: writeImpl,
+    finish: finishImpl,
+  )
+
+proc init(T: type AsyncStreamWriterVtbl, tsource: StreamTransport): T =
+  proc atEofImpl(wstream: AsyncStreamWriter): bool =
+    tsource.atEof()
+
+  proc stoppedImpl(rw: AsyncStreamWriter): bool =
+    false
+
+  proc runningImpl(rw: AsyncStreamWriter): bool =
+    tsource.running()
+
+  proc failedImpl(rw: AsyncStreamWriter): bool =
+    ## Returns ``true`` if reading/writing stream is in failed state.
+    tsource.failed()
+
+  proc writeImpl(
+      wstream: AsyncStreamWriter, pbytes: pointer, nbytes: int
+  ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    var res: int
+    try:
+      res = await write(tsource, pbytes, nbytes)
+    except TransportError as exc:
+      raise newAsyncStreamWriteError(exc)
+    if res != nbytes:
+      raise newAsyncStreamIncompleteError()
+
+  proc writeImpl(
+      wstream: AsyncStreamWriter, sbytes: seq[byte], length: int
+  ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    var res: int
+    try:
+      res = await write(tsource, sbytes, length)
+    except TransportError as exc:
+      raise newAsyncStreamWriteError(exc)
+    if res != length:
+      raise newAsyncStreamIncompleteError()
+
+  proc writeImpl(
+      wstream: AsyncStreamWriter, sbytes: string, length: int
+  ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    var res: int
+    try:
+      res = await write(tsource, sbytes, length)
+    except TransportError as exc:
+      raise newAsyncStreamWriteError(exc)
+    if res != length:
+      raise newAsyncStreamIncompleteError()
+
+  proc finishImpl(
+      wstream: AsyncStreamWriter
+  ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    discard
+
+  T(
+    atEof: atEofImpl,
+    stopped: stoppedImpl,
+    running: runningImpl,
+    failed: failedImpl,
+    writePointer: writeImpl,
+    writeSeq: writeImpl,
+    writeStr: writeImpl,
+    finish: finishImpl,
+  )
+
+proc init(
+    T: type AsyncStreamWriterVtbl,
+    wsource: AsyncStreamWriter,
+    writerLoop: StreamWriterLoop,
+): T =
+  proc atEofImpl(wstream: AsyncStreamWriter): bool =
+    if isNil(wstream.future) or wstream.future.finished():
+      true
+    else:
+      wstream.state != AsyncStreamState.Running
+
+  proc stoppedImpl(rw: AsyncStreamWriter): bool =
+    if isNil(rw.future) or rw.future.finished():
+      false
+    else:
+      rw.state == AsyncStreamState.Stopped
+
+  proc runningImpl(rw: AsyncStreamWriter): bool =
+    if isNil(rw.future) or rw.future.finished():
+      false
+    else:
+      rw.state == AsyncStreamState.Running
+
+  proc failedImpl(rw: AsyncStreamWriter): bool =
+    if isNil(rw.future) or rw.future.finished():
+      false
+    else:
+      rw.state == AsyncStreamState.Error
+
+  proc writeImpl(
+      wstream: AsyncStreamWriter, pbytes: pointer, nbytes: int
+  ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    let item = WriteItem(
+      kind: Pointer,
+      dataPtr: pbytes,
+      size: nbytes,
+      future: Future[void].Raising([CancelledError, AsyncStreamError]).init(
+          "async.stream.write(pointer)"
+        ),
+    )
+    await wstream.queue.put(item)
+    await item.future
+
+  proc writeImpl(
+      wstream: AsyncStreamWriter, sbytes: seq[byte], length: int
+  ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    let item = WriteItem(
+      kind: Sequence,
+      dataSeq: sbytes,
+      size: length,
+      future: Future[void].Raising([CancelledError, AsyncStreamError]).init(
+          "async.stream.write(seq)"
+        ),
+    )
+    await wstream.queue.put(item)
+    await item.future
+
+  proc writeImpl(
+      wstream: AsyncStreamWriter, sbytes: string, length: int
+  ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    let item = WriteItem(
+      kind: String,
+      dataStr: sbytes,
+      size: length,
+      future: Future[void].Raising([CancelledError, AsyncStreamError]).init(
+          "async.stream.write(string)"
+        ),
+    )
+    await wstream.queue.put(item)
+    await item.future
+
+  proc finishImpl(
+      wstream: AsyncStreamWriter
+  ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
+    let item = WriteItem(
+      kind: Pointer,
+      size: 0,
+      future: Future[void].Raising([CancelledError, AsyncStreamError]).init(
+          "async.stream.finish"
+        ),
+    )
+    await wstream.queue.put(item)
+    await item.future
+
+  T(
+    atEof: atEofImpl,
+    stopped: stoppedImpl,
+    running: runningImpl,
+    failed: failedImpl,
+    writePointer: writeImpl,
+    writeSeq: writeImpl,
+    writeStr: writeImpl,
+    finish: finishImpl,
+  )
+
 proc init*(child, wsource: AsyncStreamWriter, loop: StreamWriterLoop,
            queueSize = AsyncStreamDefaultQueueSize) =
   ## Initialize newly allocated object ``child`` with AsyncStreamWriter
   ## parameters.
+  child.vtbl = AsyncStreamWriterVtbl.init(wsource, loop)
+
   child.writerLoop = loop
   child.wsource = wsource
   child.tsource = wsource.tsource
@@ -885,6 +1215,8 @@ proc init*(child, rsource: AsyncStreamReader, loop: StreamReaderLoop,
            bufferSize = AsyncStreamDefaultBufferSize) =
   ## Initialize newly allocated object ``child`` with AsyncStreamReader
   ## parameters.
+  child.vtbl = AsyncStreamReaderVtbl.init(rsource, loop)
+
   child.readerLoop = loop
   child.rsource = rsource
   child.tsource = rsource.tsource
@@ -898,6 +1230,7 @@ proc init*[T](child, rsource: AsyncStreamReader, loop: StreamReaderLoop,
               udata: ref T) =
   ## Initialize newly allocated object ``child`` with AsyncStreamReader
   ## parameters.
+  child.vtbl = AsyncStreamReaderVtbl.init(rsource, loop)
   child.readerLoop = loop
   child.rsource = rsource
   child.tsource = rsource.tsource
@@ -912,6 +1245,7 @@ proc init*[T](child, rsource: AsyncStreamReader, loop: StreamReaderLoop,
 proc init*(child: AsyncStreamWriter, tsource: StreamTransport) =
   ## Initialize newly allocated object ``child`` with AsyncStreamWriter
   ## parameters.
+  child.vtbl = AsyncStreamWriterVtbl.init(tsource)
   child.writerLoop = nil
   child.wsource = nil
   child.tsource = tsource
@@ -919,9 +1253,10 @@ proc init*(child: AsyncStreamWriter, tsource: StreamTransport) =
   child.startWriter()
 
 proc init*[T](child: AsyncStreamWriter, tsource: StreamTransport,
-              udata: ref T) =
+              udata: ref T) {.deprecated.} =
   ## Initialize newly allocated object ``child`` with AsyncStreamWriter
   ## parameters.
+  child.vtbl = AsyncStreamWriterVtbl.init(tsource)
   child.writerLoop = nil
   child.wsource = nil
   child.tsource = tsource
@@ -931,6 +1266,7 @@ proc init*[T](child: AsyncStreamWriter, tsource: StreamTransport,
 proc init*(child, wsource: AsyncStreamWriter) =
   ## Initialize newly allocated object ``child`` with AsyncStreamWriter
   ## parameters.
+  child.vtbl = AsyncStreamWriterVtbl.init(wsource)
   child.writerLoop = nil
   child.wsource = wsource
   child.tsource = wsource.tsource
@@ -940,6 +1276,8 @@ proc init*(child, wsource: AsyncStreamWriter) =
 proc init*[T](child, wsource: AsyncStreamWriter, udata: ref T) =
   ## Initialize newly allocated object ``child`` with AsyncStreamWriter
   ## parameters.
+  child.vtbl = AsyncStreamWriterVtbl.init(wsource)
+
   child.writerLoop = nil
   child.wsource = wsource
   child.tsource = wsource.tsource
@@ -952,6 +1290,8 @@ proc init*[T](child, wsource: AsyncStreamWriter, udata: ref T) =
 proc init*(child: AsyncStreamReader, tsource: StreamTransport) =
   ## Initialize newly allocated object ``child`` with AsyncStreamReader
   ## parameters.
+  child.vtbl = AsyncStreamReaderVtbl.init(tsource)
+
   child.readerLoop = nil
   child.rsource = nil
   child.tsource = tsource
@@ -974,6 +1314,7 @@ proc init*[T](child: AsyncStreamReader, tsource: StreamTransport,
 proc init*(child, rsource: AsyncStreamReader) =
   ## Initialize newly allocated object ``child`` with AsyncStreamReader
   ## parameters.
+  child.vtbl = AsyncStreamReaderVtbl.init(rsource)
   child.readerLoop = nil
   child.rsource = rsource
   child.tsource = rsource.tsource
@@ -983,6 +1324,7 @@ proc init*(child, rsource: AsyncStreamReader) =
 proc init*[T](child, rsource: AsyncStreamReader, udata: ref T) =
   ## Initialize newly allocated object ``child`` with AsyncStreamReader
   ## parameters.
+  child.vtbl = AsyncStreamReaderVtbl.init(rsource)
   child.readerLoop = nil
   child.rsource = rsource
   child.tsource = rsource.tsource

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -9,7 +9,7 @@
 
 {.push raises: [].}
 
-import std/[deques, strutils]
+import std/deques
 import stew/[ptrops, shims/sequninit]
 import results
 import ".."/[asyncloop, config, handles, bipbuffer, osdefs, osutils, oserrno]
@@ -2692,31 +2692,23 @@ proc readUntil*(transp: StreamTransport, pbytes: pointer, nbytes: int,
   if nbytes == 0:
     raise newException(TransportLimitError, "Limit reached!")
 
-  var pbuffer = pbytes.toUnchecked()
-  var state = 0
-  var k = 0
+  var
+    pbuffer = pbytes.toUnchecked()
+    state = 0
+    k = 0
 
   readLoop("stream.transport.readUntil"):
     if transp.atEof():
       raise newException(TransportIncompleteError, "Data incomplete!")
 
-    var index = 0
-    for ch in transp.buffer:
-      if k >= nbytes:
-        raise newException(TransportLimitError, "Limit reached!")
+    if k == nbytes:
+      raise newException(TransportLimitError, "Limit reached!")
 
-      inc(index)
-      pbuffer[k] = ch
-      inc(k)
+    let (consumed, done) =
+      transp.buffer.copyUntil(pbuffer.toOpenArray(k, nbytes - 1), state, sep)
+    k += consumed
 
-      if sep[state] == ch:
-        inc(state)
-        if state == len(sep):
-          break
-      else:
-        state = 0
-
-    (index, state == len(sep))
+    (consumed, done)
   k
 
 proc readLine*(transp: StreamTransport, limit = 0,
@@ -2732,29 +2724,16 @@ proc readLine*(transp: StreamTransport, limit = 0,
   ## empty string.
   ##
   ## If ``limit`` more then 0, then read is limited to ``limit`` bytes.
-  var res: string
+  var
+    res: string
+    state: int
 
   readLoop("stream.transport.readLine"):
     if transp.atEof():
       (0, true)
     else:
-      var
-        consumed = 0
-        done = false
-      for ch in transp.buffer:
-        res.add char(ch)
-        consumed += 1
+      transp.buffer.addLineInto(res, state, limit, sep)
 
-        if res.endsWith(sep):
-          res.setLen(res.len - sep.len)
-          done = true
-          break
-
-        if limit > 0 and res.len == limit:
-          done = true
-          break
-
-      (consumed, done)
   res
 
 proc read*(transp: StreamTransport): Future[seq[byte]] {.

--- a/tests/testasyncstream.nim
+++ b/tests/testasyncstream.nim
@@ -8,8 +8,8 @@
 import unittest2
 import bearssl/[ssl, x509]
 import stew/byteutils
-import ".."/chronos/unittest2/asynctests
-import ".."/chronos/streams/[tlsstream, chunkstream, boundstream]
+import ../chronos/unittest2/asynctests
+import ../chronos/streams/[tlsstream, chunkstream, boundstream]
 
 {.used.}
 
@@ -850,7 +850,7 @@ suite "AsyncStream/ChunkedStream":
     await testBigData(262400, 4096)
     await testBigData(767309, 4457)
 
-  asyncTest "read small chunks":
+  asyncTest "read chunks":
     proc checkVector(inputstr: seq[byte],
                      writeChunkSize: int,
                      readChunkSize: int): Future[seq[byte]] {.async.} =
@@ -859,13 +859,12 @@ suite "AsyncStream/ChunkedStream":
         try:
           var wstream = newAsyncStreamWriter(transp)
           var wstream2 = newChunkedStreamWriter(wstream)
-          var data = inputstr
           var offset = 0
           while true:
-            if len(data) == offset:
+            if len(inputstr) == offset:
               break
-            let toWrite = min(writeChunkSize, len(data) - offset)
-            await wstream2.write(addr data[offset], toWrite)
+            let toWrite = min(writeChunkSize, len(inputstr) - offset)
+            await wstream2.write(addr inputstr[offset], toWrite)
             offset = offset + toWrite
           await wstream2.finish()
           await wstream2.closeWait()
@@ -892,61 +891,27 @@ suite "AsyncStream/ChunkedStream":
       await server.join()
       return res
 
-    proc testSmallChunk(datasize: int,
+    proc testChunk(datasize: int,
                         writeChunkSize: int,
                         readChunkSize: int): Future[bool] {.async.} =
       var data = createBigMessage("REQUESTSTREAMMESSAGE", datasize)
       var check = await checkVector(data, writeChunkSize, readChunkSize)
       return (data == check)
 
-    check waitFor(testSmallChunk(4457, 128, 1)) == true
-    check waitFor(testSmallChunk(65600, 1024, 17)) == true
-    check waitFor(testSmallChunk(262400, 4096, 61)) == true
-    check waitFor(testSmallChunk(767309, 4457, 173)) == true
+    check waitFor(testChunk(4457, 128, 1)) == true
+    check waitFor(testChunk(65600, 1024, 17)) == true
+    check waitFor(testChunk(262400, 4096, 61)) == true
+    check waitFor(testChunk(767309, 4457, 173)) == true
+    check waitFor(testChunk(767309, 4457, 173)) == true
+    check waitFor(testChunk(767309, 67000, 67001)) == true
 
 suite "AsyncStream/TLSStream":
   teardown:
     checkLeaks()
 
-  const HttpHeadersMark = @[byte(0x0D), byte(0x0A), byte(0x0D), byte(0x0A)]
-  test "Simple HTTPS connection":
-    skip()
-    # proc headerClient(address: TransportAddress,
-    #                   name: string): Future[bool] {.async: (raises: []).} =
-    #   try:
-    #     var mark = "HTTP/1.1 "
-    #     var buffer = newSeq[byte](8192)
-    #     var transp = await connect(address)
-    #     var reader = newAsyncStreamReader(transp)
-    #     var writer = newAsyncStreamWriter(transp)
-    #     var tlsstream = newTLSClientAsyncStream(reader, writer, name)
-    #     await tlsstream.writer.write("GET / HTTP/1.1\r\nHost: " & name &
-    #                                 "\r\nConnection: close\r\n\r\n")
-    #     var readFut = tlsstream.reader.readUntil(addr buffer[0], len(buffer),
-    #                                             HttpHeadersMark)
-    #     let res = await withTimeout(readFut, 5.seconds)
-    #     if res:
-    #       var length = readFut.read()
-    #       buffer.setLen(length)
-    #       if len(buffer) > len(mark):
-    #         if equalMem(addr buffer[0], addr mark[0], len(mark)):
-    #           result = true
-
-    #     await tlsstream.reader.closeWait()
-    #     await tlsstream.writer.closeWait()
-    #     await reader.closeWait()
-    #     await writer.closeWait()
-    #     await transp.closeWait()
-    #   except CatchableError as exc:
-    #     raiseAssert exc.msg
-
-    # let res = waitFor(headerClient(resolveTAddress("www.google.com:443")[0],
-    #                   "www.google.com"))
-    # check res == true
-
   asyncTest "Simple server with RSA self-signed certificate":
-    var key: TLSPrivateKey
-    var cert: TLSCertificate
+    let key = TLSPrivateKey.init(SelfSignedRsaKey)
+    let cert = TLSCertificate.init(SelfSignedRsaCert)
     let testMessage = "TEST MESSAGE"
 
     proc serveClient(server: StreamServer,
@@ -967,9 +932,6 @@ suite "AsyncStream/TLSStream":
         server.close()
       except CatchableError as exc:
         raiseAssert exc.msg
-
-    key = TLSPrivateKey.init(SelfSignedRsaKey)
-    cert = TLSCertificate.init(SelfSignedRsaCert)
 
     var server = createStreamServer(initTAddress("127.0.0.1:0"),
                                     serveClient, {ServerFlags.ReuseAddr})
@@ -1038,11 +1000,12 @@ suite "AsyncStream/TLSStream":
       await conn.closeWait()
       await server.join()
 
-  asyncTest "Custom TrustAnchors":
-    proc checkTrustAnchors(testMessage: string): Future[string] {.async.} =
-      var key = TLSPrivateKey.init(SelfSignedRsaKey)
-      var cert = TLSCertificate.init(SelfSignedRsaCert)
-      let trustAnchors = TrustAnchorStore.new(SelfSignedTrustAnchors)
+  asyncTest "chunks":
+    let key = TLSPrivateKey.init(SelfSignedRsaKey)
+    let cert = TLSCertificate.init(SelfSignedRsaCert)
+    proc checkVector(inputstr: seq[byte],
+                     writeChunkSize: int,
+                     readChunkSize: int): Future[seq[byte]] {.async.} =
 
       proc serveClient(server: StreamServer,
                       transp: StreamTransport) {.async: (raises: []).} =
@@ -1050,8 +1013,14 @@ suite "AsyncStream/TLSStream":
           var reader = newAsyncStreamReader(transp)
           var writer = newAsyncStreamWriter(transp)
           var sstream = newTLSServerAsyncStream(reader, writer, key, cert)
-          await handshake(sstream)
-          await sstream.writer.write(testMessage & "\r\n")
+          var offset = 0
+          while true:
+            if len(inputstr) == offset:
+              break
+            let toWrite = min(writeChunkSize, len(inputstr) - offset)
+            await sstream.writer.write(addr inputstr[offset], toWrite)
+            offset = offset + toWrite
+
           await sstream.writer.finish()
           await sstream.writer.closeWait()
           await sstream.reader.closeWait()
@@ -1064,142 +1033,196 @@ suite "AsyncStream/TLSStream":
           raiseAssert exc.msg
 
       var server = createStreamServer(initTAddress("127.0.0.1:0"),
-                                      serveClient, {ReuseAddr})
+                                      serveClient, {ServerFlags.ReuseAddr})
       server.start()
       var conn = await connect(server.localAddress())
       var creader = newAsyncStreamReader(conn)
       var cwriter = newAsyncStreamWriter(conn)
-      let flags = {NoVerifyServerName}
-      var cstream = newTLSClientAsyncStream(creader, cwriter, "", flags = flags,
-        trustAnchors = trustAnchors)
-      let res = await cstream.reader.read()
-      await cstream.reader.closeWait()
-      await cstream.writer.closeWait()
-      await creader.closeWait()
-      await cwriter.closeWait()
-      await conn.closeWait()
-      await server.join()
-      return string.fromBytes(res)
-    let res = waitFor checkTrustAnchors("Some message")
-    check res == "Some message\r\n"
-
-  test "Client certificate authentication":
-    proc checkClientCert(testMessage: string): Future[string] {.async.} =
-      var key = TLSPrivateKey.init(SelfSignedRsaKey)
-      var cert = TLSCertificate.init(SelfSignedRsaCert)
-
-      proc serveClient(server: StreamServer,
-                      transp: StreamTransport) {.async: (raises: []).} =
-        try:
-          var reader = newAsyncStreamReader(transp)
-          var writer = newAsyncStreamWriter(transp)
-          var sstream = newTLSServerAsyncStream(reader, writer, key, cert,
-            flags = {TLSFlags.NoRenegotiation})
-          # Configure client certificate authentication via BearSSL API.
-          # serverX509 must be stored on TLSAsyncStream to ensure it
-          # outlives the TLS session (BearSSL holds a pointer to it).
-          x509MinimalInitFull(sstream.x509,
-                              unsafeAddr SelfSignedTrustAnchors[0],
-                              uint(len(SelfSignedTrustAnchors)))
-          sslEngineSetDefaultRsavrfy(sstream.scontext.eng)
-          sslEngineSetDefaultEcdsa(sstream.scontext.eng)
-          sslServerSetTrustAnchorNamesAlt(sstream.scontext,
-            unsafeAddr SelfSignedTrustAnchors[0],
-            uint(len(SelfSignedTrustAnchors)))
-          sslEngineSetX509(sstream.scontext.eng,
-            X509ClassPointerConst(addr sstream.x509.vtable))
-          discard sslServerReset(sstream.scontext)
-          await handshake(sstream)
-          await sstream.writer.write(testMessage & "\r\n")
-          await sstream.writer.finish()
-          await sstream.writer.closeWait()
-          await sstream.reader.closeWait()
-          await reader.closeWait()
-          await writer.closeWait()
-          await transp.closeWait()
-          server.stop()
-          server.close()
-        except CatchableError as exc:
-          raiseAssert exc.msg
-
-      var server = createStreamServer(initTAddress("127.0.0.1:0"),
-                                      serveClient, {ReuseAddr})
-      server.start()
-      var conn = await connect(server.localAddress())
-      var creader = newAsyncStreamReader(conn)
-      var cwriter = newAsyncStreamWriter(conn)
+      # We are using self-signed certificate
       let flags = {NoVerifyHost, NoVerifyServerName}
-      var cstream = newTLSClientAsyncStream(creader, cwriter, "",
-        flags = flags, certificate = cert, privateKey = key)
-      let res = await cstream.reader.read()
+      var cstream = newTLSClientAsyncStream(creader, cwriter, "", flags = flags)
+      var res: seq[byte]
+      while not(cstream.reader.atEof()):
+        var chunk = await cstream.reader.read(readChunkSize)
+        res.add(chunk)
       await cstream.reader.closeWait()
       await cstream.writer.closeWait()
       await creader.closeWait()
       await cwriter.closeWait()
       await conn.closeWait()
       await server.join()
-      return string.fromBytes(res)
-    let res = waitFor checkClientCert("Client cert test")
-    check res == "Client cert test\r\n"
+      return res
 
-  test "Client certificate authentication (EC)":
-    proc checkClientCertEc(testMessage: string): Future[string] {.async.} =
-      var key = TLSPrivateKey.init(SelfSignedEcKey)
-      var cert = TLSCertificate.init(SelfSignedEcCert)
+    proc testChunk(datasize: int,
+                        writeChunkSize: int,
+                        readChunkSize: int): Future[bool] {.async.} =
+      var data = createBigMessage("REQUESTSTREAMMESSAGE", datasize)
+      var check = await checkVector(data, writeChunkSize, readChunkSize)
+      return (data == check)
 
-      proc serveClient(server: StreamServer,
-                      transp: StreamTransport) {.async: (raises: []).} =
-        try:
-          var reader = newAsyncStreamReader(transp)
-          var writer = newAsyncStreamWriter(transp)
-          var sstream = newTLSServerAsyncStream(reader, writer, key, cert,
-            flags = {TLSFlags.NoRenegotiation})
-          # Configure client certificate authentication via BearSSL API.
-          # serverX509 must be stored on TLSAsyncStream to ensure it
-          # outlives the TLS session (BearSSL holds a pointer to it).
-          x509MinimalInitFull(sstream.x509,
-                              unsafeAddr SelfSignedEcTrustAnchors[0],
-                              uint(len(SelfSignedEcTrustAnchors)))
-          sslEngineSetDefaultRsavrfy(sstream.scontext.eng)
-          sslEngineSetDefaultEcdsa(sstream.scontext.eng)
-          sslServerSetTrustAnchorNamesAlt(sstream.scontext,
-            unsafeAddr SelfSignedEcTrustAnchors[0],
-            uint(len(SelfSignedEcTrustAnchors)))
-          sslEngineSetX509(sstream.scontext.eng,
-            X509ClassPointerConst(addr sstream.x509.vtable))
-          discard sslServerReset(sstream.scontext)
-          await handshake(sstream)
-          await sstream.writer.write(testMessage & "\r\n")
-          await sstream.writer.finish()
-          await sstream.writer.closeWait()
-          await sstream.reader.closeWait()
-          await reader.closeWait()
-          await writer.closeWait()
-          await transp.closeWait()
-          server.stop()
-          server.close()
-        except CatchableError as exc:
-          raiseAssert exc.msg
+    check waitFor(testChunk(4457, 128, 1)) == true
+    check waitFor(testChunk(65600, 1024, 17)) == true
+    check waitFor(testChunk(262400, 4096, 61)) == true
+    check waitFor(testChunk(767309, 4457, 173)) == true
+    check waitFor(testChunk(767309, 4457, 173)) == true
+    check waitFor(testChunk(767309, 67000, 67001)) == true
 
-      var server = createStreamServer(initTAddress("127.0.0.1:0"),
-                                      serveClient, {ReuseAddr})
-      server.start()
-      var conn = await connect(server.localAddress())
-      var creader = newAsyncStreamReader(conn)
-      var cwriter = newAsyncStreamWriter(conn)
-      let flags = {NoVerifyHost, NoVerifyServerName}
-      var cstream = newTLSClientAsyncStream(creader, cwriter, "",
-        flags = flags, certificate = cert, privateKey = key)
-      let res = await cstream.reader.read()
-      await cstream.reader.closeWait()
-      await cstream.writer.closeWait()
-      await creader.closeWait()
-      await cwriter.closeWait()
-      await conn.closeWait()
-      await server.join()
-      return string.fromBytes(res)
-    let res = waitFor checkClientCertEc("EC client cert test")
-    check res == "EC client cert test\r\n"
+  asyncTest "Custom TrustAnchors":
+    let key = TLSPrivateKey.init(SelfSignedRsaKey)
+    let cert = TLSCertificate.init(SelfSignedRsaCert)
+    let trustAnchors = TrustAnchorStore.new(SelfSignedTrustAnchors)
+    const testMessage = "Some message\r\n"
+    proc serveClient(server: StreamServer,
+                    transp: StreamTransport) {.async: (raises: []).} =
+      try:
+        var reader = newAsyncStreamReader(transp)
+        var writer = newAsyncStreamWriter(transp)
+        var sstream = newTLSServerAsyncStream(reader, writer, key, cert)
+        await handshake(sstream)
+        await sstream.writer.write(testMessage)
+        await sstream.writer.finish()
+        await sstream.writer.closeWait()
+        await sstream.reader.closeWait()
+        await reader.closeWait()
+        await writer.closeWait()
+        await transp.closeWait()
+        server.stop()
+        server.close()
+      except CatchableError as exc:
+        raiseAssert exc.msg
+
+    var server = createStreamServer(initTAddress("127.0.0.1:0"),
+                                    serveClient, {ReuseAddr})
+    server.start()
+    var conn = await connect(server.localAddress())
+    var creader = newAsyncStreamReader(conn)
+    var cwriter = newAsyncStreamWriter(conn)
+    let flags = {NoVerifyServerName}
+    var cstream = newTLSClientAsyncStream(creader, cwriter, "", flags = flags,
+      trustAnchors = trustAnchors)
+    let res = await cstream.reader.read()
+    await cstream.reader.closeWait()
+    await cstream.writer.closeWait()
+    await creader.closeWait()
+    await cwriter.closeWait()
+    await conn.closeWait()
+    await server.join()
+    check: string.fromBytes(res) == testMessage
+
+  asyncTest "Client certificate authentication":
+    let key = TLSPrivateKey.init(SelfSignedRsaKey)
+    let cert = TLSCertificate.init(SelfSignedRsaCert)
+    const testMessage = "Client cert test\r\n"
+
+    proc serveClient(server: StreamServer,
+                    transp: StreamTransport) {.async: (raises: []).} =
+      try:
+        var reader = newAsyncStreamReader(transp)
+        var writer = newAsyncStreamWriter(transp)
+        var sstream = newTLSServerAsyncStream(reader, writer, key, cert,
+          flags = {TLSFlags.NoRenegotiation})
+        # Configure client certificate authentication via BearSSL API.
+        # serverX509 must be stored on TLSAsyncStream to ensure it
+        # outlives the TLS session (BearSSL holds a pointer to it).
+        x509MinimalInitFull(sstream.x509,
+                            unsafeAddr SelfSignedTrustAnchors[0],
+                            uint(len(SelfSignedTrustAnchors)))
+        sslEngineSetDefaultRsavrfy(sstream.scontext.eng)
+        sslEngineSetDefaultEcdsa(sstream.scontext.eng)
+        sslServerSetTrustAnchorNamesAlt(sstream.scontext,
+          unsafeAddr SelfSignedTrustAnchors[0],
+          uint(len(SelfSignedTrustAnchors)))
+        sslEngineSetX509(sstream.scontext.eng,
+          X509ClassPointerConst(addr sstream.x509.vtable))
+        discard sslServerReset(sstream.scontext)
+        await handshake(sstream)
+        await sstream.writer.write(testMessage)
+        await sstream.writer.finish()
+        await sstream.writer.closeWait()
+        await sstream.reader.closeWait()
+        await reader.closeWait()
+        await writer.closeWait()
+        await transp.closeWait()
+        server.stop()
+        server.close()
+      except CatchableError as exc:
+        raiseAssert exc.msg
+
+    var server = createStreamServer(initTAddress("127.0.0.1:0"),
+                                    serveClient, {ReuseAddr})
+    server.start()
+    var conn = await connect(server.localAddress())
+    var creader = newAsyncStreamReader(conn)
+    var cwriter = newAsyncStreamWriter(conn)
+    let flags = {NoVerifyHost, NoVerifyServerName}
+    var cstream = newTLSClientAsyncStream(creader, cwriter, "",
+      flags = flags, certificate = cert, privateKey = key)
+    let res = await cstream.reader.read()
+    await cstream.reader.closeWait()
+    await cstream.writer.closeWait()
+    await creader.closeWait()
+    await cwriter.closeWait()
+    await conn.closeWait()
+    await server.join()
+    check:
+      string.fromBytes(res) == testMessage
+
+  asyncTest "Client certificate authentication (EC)":
+    let key = TLSPrivateKey.init(SelfSignedEcKey)
+    let cert = TLSCertificate.init(SelfSignedEcCert)
+    const testMessage = "EC client cert test\r\n"
+    proc serveClient(server: StreamServer,
+                    transp: StreamTransport) {.async: (raises: []).} =
+      try:
+        var reader = newAsyncStreamReader(transp)
+        var writer = newAsyncStreamWriter(transp)
+        var sstream = newTLSServerAsyncStream(reader, writer, key, cert,
+          flags = {TLSFlags.NoRenegotiation})
+        # Configure client certificate authentication via BearSSL API.
+        # serverX509 must be stored on TLSAsyncStream to ensure it
+        # outlives the TLS session (BearSSL holds a pointer to it).
+        x509MinimalInitFull(sstream.x509,
+                            unsafeAddr SelfSignedEcTrustAnchors[0],
+                            uint(len(SelfSignedEcTrustAnchors)))
+        sslEngineSetDefaultRsavrfy(sstream.scontext.eng)
+        sslEngineSetDefaultEcdsa(sstream.scontext.eng)
+        sslServerSetTrustAnchorNamesAlt(sstream.scontext,
+          unsafeAddr SelfSignedEcTrustAnchors[0],
+          uint(len(SelfSignedEcTrustAnchors)))
+        sslEngineSetX509(sstream.scontext.eng,
+          X509ClassPointerConst(addr sstream.x509.vtable))
+        discard sslServerReset(sstream.scontext)
+        await handshake(sstream)
+        await sstream.writer.write(testMessage)
+        await sstream.writer.finish()
+        await sstream.writer.closeWait()
+        await sstream.reader.closeWait()
+        await reader.closeWait()
+        await writer.closeWait()
+        await transp.closeWait()
+        server.stop()
+        server.close()
+      except CatchableError as exc:
+        raiseAssert exc.msg
+
+    var server = createStreamServer(initTAddress("127.0.0.1:0"),
+                                    serveClient, {ReuseAddr})
+    server.start()
+    var conn = await connect(server.localAddress())
+    var creader = newAsyncStreamReader(conn)
+    var cwriter = newAsyncStreamWriter(conn)
+    let flags = {NoVerifyHost, NoVerifyServerName}
+    var cstream = newTLSClientAsyncStream(creader, cwriter, "",
+      flags = flags, certificate = cert, privateKey = key)
+    let res = await cstream.reader.read()
+    await cstream.reader.closeWait()
+    await cstream.writer.closeWait()
+    await creader.closeWait()
+    await cwriter.closeWait()
+    await conn.closeWait()
+    await server.join()
+    check:
+      string.fromBytes(res) == testMessage
 
 suite "AsyncStream/BoundedStream":
   teardown:

--- a/tests/testasyncstream.nim
+++ b/tests/testasyncstream.nim
@@ -864,7 +864,7 @@ suite "AsyncStream/ChunkedStream":
             if len(inputstr) == offset:
               break
             let toWrite = min(writeChunkSize, len(inputstr) - offset)
-            await wstream2.write(addr inputstr[offset], toWrite)
+            await wstream2.write(unsafeAddr inputstr[offset], toWrite)
             offset = offset + toWrite
           await wstream2.finish()
           await wstream2.closeWait()


### PR DESCRIPTION
Currently, async readers and writers are implemented using a mechanism where each layer implements a read/write loop that reads/writes from an intermediate buffer - a write to a stream is placed in a queue and a write loop reads from that queue, processes the data and forward it to the next "layer".

The sink layer then writes the data to a transport and translates the errors and exceptions coming back.

While this approach works, it has a few downsides:

* Each layer introduces additional latency - for example, a http body writer that has a bounded writer and maybe one more layer has to go through 3-4 async loop iterations before the data reaches the socket - this means a lot of additional latency specially in a busy applications where the loop has lots of work to do
* For string/seq, each layer also introduces at least two full data copies - in and out of the queue (plus the usual async overhead)
* The "top" layer must keep track of the full stack of streams underneath to close them, ie HttpBodyWriter has a `seq[...]` of streams it needs to manage - logically though, it should only have to keep track of one.
* The buffering is mandatory - there's no way to write a lightweight "observer" stream that doesn't use the buffer - this is due to how the extension mechanism has flow control for selecting implementation using an `if/else` construct that cannot be extended by the stream.
* Every cal lhas to go through the `if/else` construct every time even though the conditions are fixed per stream type

This commit introduces a (classic) alternative where streams inherit from each other - this allows each stream to choose its own buffering strategy and thus avoid the queue/loop/copy problems.

Closing streams can now be implemented using an ownership cascade where the top layer closes the layer under it when requested but no longer has to manage multiple layers.

There are a few downsides too - the API wide meaning that each layer has to implement a large number of functions - readOnce, readExactly and so on - in the current implementation, only the loop needs replacing.

The aim of this first step is to introduce the VTable which removes the `if/else` construct in favor of function pointers that are assigned on construction - more work is needed to take advantage of the vtables and solve the other issues.