### PR TITLE
future: another  `sink` attempt

### DIFF
--- a/chronos/config.nim
+++ b/chronos/config.nim
@@ -102,6 +102,15 @@ const
   chronosTLSSessionCacheBufferSize* {.intdefine.} = 4096
     ## Default size of chronos TLS Session cache's internal buffer.
 
+  chronosUseSink* {.booldefine.} = (NimMajor, NimMinor, NimPatch) >= (2, 0, 6)
+    ## Whether or not to use `sink` - using a recent Nim version helps:
+    ## * https://github.com/nim-lang/Nim/issues/23354
+    ## * https://github.com/nim-lang/Nim/issues/22175
+    ##
+    ## https://github.com/nim-lang/Nim/issues/12340 is a particularily serious
+    ## bug but it does not affect chronos' usage as long as values are not
+    ## moved out of Future (at the time of writing we only move values)
+
 when defined(chronosStrictException):
   {.warning: "-d:chronosStrictException has been deprecated in favor of handleException".}
   # In chronos v3, this setting was used as the opposite of
@@ -131,38 +140,10 @@ when defined(debug) or defined(chronosConfig):
     printOption("chronosTLSSessionCacheBufferSize",
       chronosTLSSessionCacheBufferSize)
 
-# In nim 1.6, `sink` + local variable + `move` generates the best code for
-# moving a proc parameter into a closure - this only works for closure
-# procedures however - in closure iterators, the parameter is always copied
-# into the closure (!) meaning that non-raw `{.async.}` functions always carry
-# this overhead, sink or no. See usages of chronosMoveSink for examples.
-# In addition, we need to work around https://github.com/nim-lang/Nim/issues/22175
-# which has not been backported to 1.6.
-# Long story short, the workaround is not needed in non-raw {.async.} because
-# a copy of the literal is always made.
-# TODO review the above for 2.0 / 2.0+refc
-type
-  SeqHeader = object
-    length, reserved: int
+when chronosUseSink:
+  template chronosSink*[T] = sink[T]
+  template chronosMoveSink*(v: sink auto): untyped = move(v)
+else:
+  template chronosSink*[T] = T
+  template chronosMoveSink*(v: sink auto): untyped = v
 
-proc isLiteral(s: string): bool {.inline.} =
-  when defined(gcOrc) or defined(gcArc):
-    false
-  else:
-    s.len > 0 and (cast[ptr SeqHeader](s).reserved and (1 shl (sizeof(int) * 8 - 2))) != 0
-
-proc isLiteral[T](s: seq[T]): bool {.inline.} =
-  when defined(gcOrc) or defined(gcArc):
-    false
-  else:
-    s.len > 0 and (cast[ptr SeqHeader](s).reserved and (1 shl (sizeof(int) * 8 - 2))) != 0
-
-template chronosMoveSink*(val: auto): untyped =
-  bind isLiteral
-  when not (defined(gcOrc) or defined(gcArc)) and val is seq|string:
-    if isLiteral(val):
-      val
-    else:
-      move(val)
-  else:
-    move(val)

--- a/chronos/config.nim
+++ b/chronos/config.nim
@@ -141,9 +141,9 @@ when defined(debug) or defined(chronosConfig):
       chronosTLSSessionCacheBufferSize)
 
 when chronosUseSink:
-  template chronosSink*[T] = sink[T]
+  template chronosSink*(T: type): type = sink T
   template chronosMoveSink*(v: sink auto): untyped = move(v)
 else:
-  template chronosSink*[T] = T
+  template chronosSink*(T: type): type = T
   template chronosMoveSink*(v: sink auto): untyped = v
 

--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -195,14 +195,14 @@ proc finish(fut: FutureBase, state: FutureState) =
   when chronosFutureTracking:
     scheduleDestructor(fut)
 
-proc complete[T: not void](future: Future[T], val: chronosSink[T], loc: ptr SrcLoc) =
+proc complete[T: not void](future: Future[T], val: chronosSink T, loc: ptr SrcLoc) =
   if not(future.cancelled()):
     checkFinished(future, loc)
     doAssert(isNil(future.internalError))
     future.internalValue = chronosMoveSink(val)
     future.finish(FutureState.Completed)
 
-template complete*[T: not void](future: Future[T], val: T) =
+template complete*[T: not void](future: Future[T], val: chronosSink T) =
   ## Completes ``future`` with value ``val``.
   complete(future, val, getSrcLocation())
 

--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -195,7 +195,7 @@ proc finish(fut: FutureBase, state: FutureState) =
   when chronosFutureTracking:
     scheduleDestructor(fut)
 
-proc complete[T: not void](future: Future[T], val: chronosSink T, loc: ptr SrcLoc) =
+proc complete[T: not void](future: Future[T], val: chronosSink[T], loc: ptr SrcLoc) =
   if not(future.cancelled()):
     checkFinished(future, loc)
     doAssert(isNil(future.internalError))

--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -195,14 +195,14 @@ proc finish(fut: FutureBase, state: FutureState) =
   when chronosFutureTracking:
     scheduleDestructor(fut)
 
-proc complete[T](future: Future[T], val: T, loc: ptr SrcLoc) =
+proc complete[T: not void](future: Future[T], val: chronosSink T, loc: ptr SrcLoc) =
   if not(future.cancelled()):
     checkFinished(future, loc)
     doAssert(isNil(future.internalError))
-    future.internalValue = val
+    future.internalValue = chronosMoveSink(val)
     future.finish(FutureState.Completed)
 
-template complete*[T](future: Future[T], val: T) =
+template complete*[T: not void](future: Future[T], val: T) =
   ## Completes ``future`` with value ``val``.
   complete(future, val, getSrcLocation())
 


### PR DESCRIPTION
Previous attempts have been reverted due to
https://github.com/nim-lang/Nim/issues/23354.

Incidentally, we can also remove the workaround for [literals](https://github.com/nim-lang/Nim/issues/22175) since we gate the usage of sink from 2.0.6.

We also have to be mindful of https://github.com/nim-lang/Nim/issues/12340 which does not affect this particular usage of sink but is adjacent enough that it could cause trouble in the future, if we also move the value _out_ of the future.

Pre (2.2.4, refc):
```
| Small/small    |    0.059s |   1000 | 17070.173 |    0.031 MB |    0.016 MB |    0.521 MB/s |    0.277 MB/s |
| Medium/small   |    0.887s |   1000 | 1127.296 | 1000.000 MB |    0.021 MB | 1127.296 MB/s |    0.024 MB/s |
| Small/Medium   |    1.218s |   1000 |  820.972 |    0.031 MB | 1000.000 MB |    0.025 MB/s |  820.972 MB/s |
| Medium/Medium  |    1.679s |   1000 |  595.596 | 1000.000 MB | 1000.000 MB |  595.596 MB/s |  595.596 MB/s |
```

Post (2.2.4, refc):
```
| Small/small    |    0.063s |   1000 | 15865.303 |    0.031 MB |    0.016 MB |    0.484 MB/s |    0.257 MB/s |
| Medium/small   |    0.784s |   1000 | 1275.976 | 1000.000 MB |    0.021 MB | 1275.976 MB/s |    0.027 MB/s |
| Small/Medium   |    1.024s |   1000 |  976.662 |    0.031 MB | 1000.000 MB |    0.030 MB/s |  976.662 MB/s |
| Medium/Medium  |    1.435s |   1000 |  696.936 | 1000.000 MB | 1000.000 MB |  696.936 MB/s |  696.936 MB/s |
```

Notably, orc is [very slow](https://github.com/nim-lang/Nim/issues/25719) - using devel which already has some improvements:

```
| Small/small    |    0.050s |   1000 | 19820.812 |    0.031 MB |    0.016 MB |    0.605 MB/s |    0.321 MB/s |
| Medium/small   |    1.504s |   1000 |  665.016 | 1000.000 MB |    0.021 MB |  665.016 MB/s |    0.014 MB/s |
| Small/Medium   |    1.827s |   1000 |  547.325 |    0.031 MB | 1000.000 MB |    0.017 MB/s |  547.325 MB/s |
| Medium/Medium  |    2.145s |   1000 |  466.266 | 1000.000 MB | 1000.000 MB |  466.266 MB/s |  466.266 MB/s |
```