### PR TITLE
Add ALPN support to TLSStream

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -10,7 +10,7 @@ skipDirs      = @["tests"]
 requires "nim >= 1.6.16",
          "results",
          "stew >= 0.5.0",
-         "bearssl >= 0.2.7",
+         "bearssl >= 0.2.8",
          "httputils",
          "unittest2"
 

--- a/chronos/streams/tlsstream.nim
+++ b/chronos/streams/tlsstream.nim
@@ -578,11 +578,8 @@ proc newTLSClientAsyncStream*(
 
   if alpnProtocols.len > 0:
     res.alpnProtos = allocCStringArray(alpnProtocols)
-    # BearSSL declares protocol_names as `const char **` but the Nim binding
-    # types it as cstringArray (`char **`). Direct assignment fails on
-    # GCC 14+ where -Wincompatible-pointer-types is an error by default.
-    {.emit: [res.ccontext.eng, ".protocol_names = (const char **)", res.alpnProtos, ";"].}
-    res.ccontext.eng.protocolNamesNum = uint16(alpnProtocols.len)
+    sslEngineSetProtocolNames(res.ccontext.eng, res.alpnProtos,
+                              uint(alpnProtocols.len))
 
   if TLSFlags.NoVerifyServerName in flags:
     let err = sslClientReset(res.ccontext, nil, 0)
@@ -681,11 +678,8 @@ proc newTLSServerAsyncStream*(rsource: AsyncStreamReader,
 
   if alpnProtocols.len > 0:
     res.alpnProtos = allocCStringArray(alpnProtocols)
-    # BearSSL declares protocol_names as `const char **` but the Nim binding
-    # types it as cstringArray (`char **`). Direct assignment fails on
-    # GCC 14+ where -Wincompatible-pointer-types is an error by default.
-    {.emit: [res.scontext.eng, ".protocol_names = (const char **)", res.alpnProtos, ";"].}
-    res.scontext.eng.protocolNamesNum = uint16(alpnProtocols.len)
+    sslEngineSetProtocolNames(res.scontext.eng, res.alpnProtos,
+                              uint(alpnProtocols.len))
 
   let err = sslServerReset(res.scontext)
   if err == 0:

--- a/chronos/streams/tlsstream.nim
+++ b/chronos/streams/tlsstream.nim
@@ -101,6 +101,7 @@ type
     trustAnchors: TrustAnchorStore
     clientCertificate: TLSCertificate
     clientPrivateKey: TLSPrivateKey
+    alpnProtos: cstringArray
 
   SomeTLSStreamType* = TLSStreamReader|TLSStreamWriter|TLSAsyncStream
   SomeTrustAnchorType* = TrustAnchorStore | openArray[X509TrustAnchor]
@@ -430,6 +431,10 @@ proc tlsLoop*(stream: TLSAsyncStream) {.async: (raises: []).} =
               "Connection to the remote peer has been lost")
           )
 
+  if not isNil(stream.alpnProtos):
+    deallocCStringArray(stream.alpnProtos)
+    stream.alpnProtos = nil
+
   # Completing readers
   stream.reader.buffer.forget()
 
@@ -470,7 +475,8 @@ proc newTLSClientAsyncStream*(
        flags: set[TLSFlags] = {},
        trustAnchors: SomeTrustAnchorType = MozillaTrustAnchors,
        certificate: TLSCertificate = nil,
-       privateKey: TLSPrivateKey = nil
+       privateKey: TLSPrivateKey = nil,
+       alpnProtocols: openArray[string] = []
      ): TLSAsyncStream {.raises: [TLSStreamInitError].} =
   ## Create new TLS asynchronous stream for outbound (client) connections
   ## using reading stream ``rsource`` and writing stream ``wsource``.
@@ -570,6 +576,14 @@ proc newTLSClientAsyncStream*(
                            cuint(algo), ecGetDefault(),
                            ecdsaSignAsn1GetDefault())
 
+  if alpnProtocols.len > 0:
+    res.alpnProtos = allocCStringArray(alpnProtocols)
+    # BearSSL declares protocol_names as `const char **` but the Nim binding
+    # types it as cstringArray (`char **`). Direct assignment fails on
+    # GCC 14+ where -Wincompatible-pointer-types is an error by default.
+    {.emit: [res.ccontext.eng, ".protocol_names = (const char **)", res.alpnProtos, ";"].}
+    res.ccontext.eng.protocolNamesNum = uint16(alpnProtocols.len)
+
   if TLSFlags.NoVerifyServerName in flags:
     let err = sslClientReset(res.ccontext, nil, 0)
     if err == 0:
@@ -597,7 +611,9 @@ proc newTLSServerAsyncStream*(rsource: AsyncStreamReader,
                               minVersion = TLSVersion.TLS11,
                               maxVersion = TLSVersion.TLS12,
                               cache: TLSSessionCache = nil,
-                              flags: set[TLSFlags] = {}): TLSAsyncStream {.
+                              flags: set[TLSFlags] = {},
+                              alpnProtocols: openArray[string] = []
+                              ): TLSAsyncStream {.
      raises: [TLSStreamInitError, TLSStreamProtocolError].} =
   ## Create new TLS asynchronous stream for inbound (server) connections
   ## using reading stream ``rsource`` and writing stream ``wsource``.
@@ -662,6 +678,14 @@ proc newTLSServerAsyncStream*(rsource: AsyncStreamReader,
     sslEngineAddFlags(res.scontext.eng, OPT_TOLERATE_NO_CLIENT_AUTH)
   if TLSFlags.FailOnAlpnMismatch in flags:
     sslEngineAddFlags(res.scontext.eng, OPT_FAIL_ON_ALPN_MISMATCH)
+
+  if alpnProtocols.len > 0:
+    res.alpnProtos = allocCStringArray(alpnProtocols)
+    # BearSSL declares protocol_names as `const char **` but the Nim binding
+    # types it as cstringArray (`char **`). Direct assignment fails on
+    # GCC 14+ where -Wincompatible-pointer-types is an error by default.
+    {.emit: [res.scontext.eng, ".protocol_names = (const char **)", res.alpnProtos, ";"].}
+    res.scontext.eng.protocolNamesNum = uint16(alpnProtocols.len)
 
   let err = sslServerReset(res.scontext)
   if err == 0:
@@ -855,3 +879,17 @@ proc handshake*(rws: SomeTLSStreamType): Future[void] {.
       rws.reader.handshakeFut = retFuture
       rws.writer.handshakeFut = retFuture
   retFuture
+
+proc getSelectedAlpnProtocol*(stream: TLSAsyncStream): string =
+  ## Returns the application protocol selected during the TLS handshake
+  ## via ALPN. Returns an empty string if no protocol was negotiated.
+  ## This proc should be called after the handshake is complete.
+  let engine =
+    case stream.reader.kind
+    of TLSStreamKind.Client:
+      addr stream.ccontext.eng
+    of TLSStreamKind.Server:
+      addr stream.scontext.eng
+  let proto = sslEngineGetSelectedProtocol(engine[])
+  if not isNil(proto):
+    return $proto

--- a/tests/testasyncstream.nim
+++ b/tests/testasyncstream.nim
@@ -1095,6 +1095,54 @@ suite "AsyncStream/TLSStream":
     let res = waitFor checkClientCertEc("EC client cert test")
     check res == "EC client cert test\r\n"
 
+  asyncTest "ALPN negotiation":
+    var key = TLSPrivateKey.init(SelfSignedRsaKey)
+    var cert = TLSCertificate.init(SelfSignedRsaCert)
+    var serverAlpn = ""
+
+    proc serveClient(server: StreamServer,
+                     transp: StreamTransport) {.async: (raises: []).} =
+      try:
+        var reader = newAsyncStreamReader(transp)
+        var writer = newAsyncStreamWriter(transp)
+        var sstream = newTLSServerAsyncStream(reader, writer, key, cert,
+          alpnProtocols = ["h2", "http/1.1"])
+        await handshake(sstream)
+        serverAlpn = getSelectedAlpnProtocol(sstream)
+        await sstream.writer.write(serverAlpn & "\r\n")
+        await sstream.writer.finish()
+        await sstream.writer.closeWait()
+        await sstream.reader.closeWait()
+        await reader.closeWait()
+        await writer.closeWait()
+        await transp.closeWait()
+        server.stop()
+        server.close()
+      except CatchableError as exc:
+        raiseAssert exc.msg
+
+    let flags = {NoVerifyHost, NoVerifyServerName}
+    var server = createStreamServer(initTAddress("127.0.0.1:0"),
+                                    serveClient, {ServerFlags.ReuseAddr})
+    server.start()
+    var conn = await connect(server.localAddress())
+    var creader = newAsyncStreamReader(conn)
+    var cwriter = newAsyncStreamWriter(conn)
+    var cstream = newTLSClientAsyncStream(creader, cwriter, "",
+      flags = flags, alpnProtocols = ["h2", "http/1.1"])
+    await handshake(cstream)
+    let clientAlpn = getSelectedAlpnProtocol(cstream)
+    let res = await cstream.reader.read()
+    await cstream.reader.closeWait()
+    await cstream.writer.closeWait()
+    await creader.closeWait()
+    await cwriter.closeWait()
+    await conn.closeWait()
+    await server.join()
+    check serverAlpn == "h2"
+    check clientAlpn == "h2"
+    check string.fromBytes(res) == "h2\r\n"
+
 suite "AsyncStream/BoundedStream":
   teardown:
     checkLeaks()


### PR DESCRIPTION
Add Application-Layer Protocol Negotiation (ALPN) support to TLSStream for both client/server connections.

`{.emit.}` is used to set protocol_names on the BearSSL engine because the C header declares it as `const char **` while the Nim binding types it as `cstringArray (char **)`. Direct assignment fails on gcc 14+ where -Wincompatible-pointer-types is an error by default. Should I send a PR to nim-bearssl to fix the binding?