### PR TITLE
http: avoid some copies

### DIFF
--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import std/[uri, tables, sequtils]
-import stew/[base10, base64, byteutils], httputils, results
+import stew/[base10, base64, byteutils, ptrops], httputils, results
 import ../../asyncloop, ../../asyncsync
 import ../../streams/[asyncstream, tlsstream, chunkstream, boundstream]
 import httptable, httpcommon, httpagent, httpbodyrw, multipart
@@ -1204,7 +1204,9 @@ proc send*(request: HttpClientRequestRef): Future[HttpClientResponseRef] {.
     request.connection.state = HttpClientConnectionState.RequestHeadersSent
     request.connection.state = HttpClientConnectionState.RequestBodySending
     if len(request.buffer) > 0:
-      await request.connection.writer.write(move(request.buffer))
+      # TODO https://github.com/status-im/nim-chronos/issues/578
+      await request.connection.writer.write(baseAddr request.buffer, request.buffer.len)
+      request.buffer.reset()
     request.connection.state = HttpClientConnectionState.RequestBodySent
     request.state = HttpReqRespState.Finished
     request.setDuration()
@@ -1506,11 +1508,13 @@ proc fetch*(request: HttpClientRequestRef): Future[HttpResponseTuple] {.
   var response: HttpClientResponseRef
   try:
     response = await request.send()
-    let buffer = await response.getBodyBytes()
+    # TODO https://github.com/status-im/nim-chronos/issues/601
+    var buffer = await response.getBodyBytes()
     let status = response.status
     await response.closeWait()
     response = nil
-    (status, buffer)
+    # TODO https://github.com/nim-lang/Nim/issues/25057
+    (status, move(buffer))
   except HttpError as exc:
     if not(isNil(response)): await response.closeWait()
     raise exc
@@ -1561,14 +1565,16 @@ proc fetch*(session: HttpSessionRef, url: Uri): Future[HttpResponseTuple] {.
         request = redirect
         redirect = nil
       else:
-        let
+        var
+          # TODO https://github.com/status-im/nim-chronos/issues/601
           data = await response.getBodyBytes()
           code = response.status
         await response.closeWait()
         response = nil
         await request.closeWait()
         request = nil
-        return (code, data)
+        # TODO https://github.com/nim-lang/Nim/issues/25057
+        return (code, move(data))
     except CancelledError as exc:
       var pending: seq[Future[void]]
       if not(isNil(response)): pending.add(closeWait(response))

--- a/chronos/apps/http/httpserver.nim
+++ b/chronos/apps/http/httpserver.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import std/[tables, uri, strutils]
-import stew/[base10], httputils, results
+import stew/[base10, ptrops], httputils, results
 import ../../[asyncloop, asyncsync, config]
 import ../../streams/[asyncstream, boundstream, chunkstream]
 import "."/[httptable, httpcommon, multipart]
@@ -1414,21 +1414,8 @@ proc sendBody*(resp: HttpResponseRef, pbytes: pointer, nbytes: int) {.
 proc sendBody*(resp: HttpResponseRef, data: ByteChar) {.
      async: (raises: [CancelledError, HttpWriteError]).} =
   ## Send HTTP response at once by using data ``data``.
-  checkPending(resp)
-  let responseHeaders = resp.prepareLengthHeaders(len(data))
-  resp.setResponseState(HttpResponseState.Prepared)
-  try:
-    resp.setResponseState(HttpResponseState.Sending)
-    await resp.connection.writer.write(responseHeaders)
-    if len(data) > 0:
-      await resp.connection.writer.write(data)
-    resp.setResponseState(HttpResponseState.Finished)
-  except CancelledError as exc:
-    resp.setResponseState(HttpResponseState.Cancelled)
-    raise exc
-  except AsyncStreamError as exc:
-    resp.setResponseState(HttpResponseState.Failed)
-    raiseHttpWriteError("Unable to send response body, reason: " & $exc.msg)
+  # TODO https://github.com/status-im/nim-chronos/issues/578
+  await resp.sendBody(baseAddr data, data.len) # await to keep data alive
 
 proc sendError*(resp: HttpResponseRef, code: HttpCode, body = "") {.
      async: (raises: [CancelledError, HttpWriteError]).} =
@@ -1583,7 +1570,8 @@ proc respond*(req: HttpRequestRef, code: HttpCode, content: ByteChar,
   response.status = code
   for k, v in headers.stringItems():
     response.addHeader(k, v)
-  await response.sendBody(content)
+  # TODO https://github.com/status-im/nim-chronos/issues/578
+  await response.sendBody(baseAddr content, content.len)
   response
 
 proc respond*(req: HttpRequestRef, code: HttpCode,

--- a/chronos/apps/http/httpserver.nim
+++ b/chronos/apps/http/httpserver.nim
@@ -1295,7 +1295,7 @@ template checkResponseCanBeModified(t: untyped) =
            "Response could not be modified at this stage")
 
 template checkPointerLength(t1, t2: untyped) =
-  doAssert(not(isNil(t1)), "pbytes must not be nil")
+  doAssert(not(isNil(t1)) or t2 == 0, "pbytes must not be nil")
   doAssert(t2 >= 0, "nbytes should be bigger or equal to zero")
 
 proc setHeader*(resp: HttpResponseRef, key, value: string) =


### PR DESCRIPTION
While waiting for:

* https://github.com/status-im/nim-chronos/issues/601
* https://github.com/status-im/nim-chronos/issues/578
* https://github.com/nim-lang/Nim/issues/25057

In particular, the move-on-return are ugly but needed for #639 to do its job well