### PR TITLE
streams: cleanup

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -45,7 +45,7 @@ proc build(args, path: string) =
 
 proc run(args, path: string) =
   build args, path
-  exec "build/" & path.splitPath[1]
+  exec "build/" & path.splitPath[1] & " -v"
 
 task examples, "Build examples":
   # Build book examples

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -64,7 +64,7 @@ task test, "Run all tests":
   for args in testArguments:
     # First run tests with `refc` memory manager.
     run args & " --mm:refc", "tests/testall"
-    if (NimMajor, NimMinor) > (1, 6):
+    if (NimMajor, NimMinor) >= (2, 2): # ORC on 2.0 is too broken to investigate
       run args & " --mm:orc", "tests/testall"
 
   # Make sure benchmarks compile

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -45,7 +45,7 @@ proc build(args, path: string) =
 
 proc run(args, path: string) =
   build args, path
-  exec "build/" & path.splitPath[1] & " -v"
+  exec "build/" & path.splitPath[1]
 
 task examples, "Build examples":
   # Build book examples
@@ -74,7 +74,7 @@ task test, "Run all tests":
 
 task test_v3_compat, "Run all tests in v3 compatibility mode":
   for args in testArguments:
-    if (NimMajor, NimMinor) > (1, 6):
+    if (NimMajor, NimMinor) >= (2, 2):
       # First run tests with `refc` memory manager.
       run args & " --mm:refc -d:chronosHandleException", "tests/testall"
 
@@ -89,7 +89,7 @@ task test_libbacktrace, "test with libbacktrace":
     for args in allArgs:
       # First run tests with `refc` memory manager.
       run args & " --mm:refc", "tests/testall"
-      if (NimMajor, NimMinor) > (1, 6):
+      if (NimMajor, NimMinor) >= (2, 2):
         run args & " --mm:orc", "tests/testall"
 
 task docs, "Generate API documentation":

--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -63,7 +63,6 @@ type
   #
   # The vtable approach has not yet ossified, ie it's beta and may change
   # between releases.
-
   ReadOnceProc* = proc(
     rstream: AsyncStreamReader, pbytes: pointer, nbytes: int
   ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).}
@@ -85,13 +84,7 @@ type
     readLine*: proc(rstream: AsyncStreamReader, limit = 0, sep = "\r\n"): Future[string] {.
       async: (raises: [CancelledError, AsyncStreamError])
     .}
-    read*: proc(rstream: AsyncStreamReader): Future[seq[byte]] {.
-      async: (raises: [CancelledError, AsyncStreamError])
-    .}
     readN*: proc(rstream: AsyncStreamReader, n: int): Future[seq[byte]] {.
-      async: (raises: [CancelledError, AsyncStreamError])
-    .}
-    consume*: proc(rstream: AsyncStreamReader): Future[int] {.
       async: (raises: [CancelledError, AsyncStreamError])
     .}
     consumeN*: proc(rstream: AsyncStreamReader, n: int): Future[int] {.
@@ -150,7 +143,7 @@ type
     offset*: int
     future*: Future[void].Raising([CancelledError, AsyncStreamError])
 
-  AsyncStreamState* = enum
+  AsyncStreamState* {.pure.} = enum
     Running,  ## Stream is online and working
     Error,    ## Stream has stored error
     Stopped,  ## Stream was closed while working
@@ -225,7 +218,7 @@ proc upload*(sb: AsyncBufferRef, pbytes: ptr byte,
   ## via chunks of size up to internal buffer size.
   var
     length = nbytes
-    srcBuffer = pbytes.toUnchecked()
+    srcBuffer = cast[ptr byte](pbytes).makeUncheckedArray()
     offset = 0
 
   while length > 0:
@@ -291,10 +284,6 @@ proc raiseAsyncStreamIncompleteError*() {.
      noinline, noreturn, raises: [AsyncStreamIncompleteError].} =
   raise newAsyncStreamIncompleteError()
 
-proc raiseEmptyMessageDefect*() {.noinline, noreturn.} =
-  raise newException(AsyncStreamIncorrectDefect,
-                     "Could not write empty message")
-
 proc newAsyncStreamWriteEOFError*(): ref AsyncStreamWriteEOFError {.noinline.} =
   newException(AsyncStreamWriteEOFError,
                "Stream finished or remote side dropped connection")
@@ -314,7 +303,7 @@ proc atEof*(wstream: AsyncStreamWriter): bool =
 
 proc closed*(rw: AsyncStreamRW): bool =
   ## Returns ``true`` is reading/writing stream is closed.
-  rw.state in {AsyncStreamState.Closing, Closed}
+  rw.state in {AsyncStreamState.Closing, AsyncStreamState.Closed}
 
 proc finished*(rw: AsyncStreamRW): bool =
   ## Returns ``true`` if reading/writing stream is finished (completed).
@@ -340,7 +329,6 @@ template checkStreamClosed(t: untyped, T: type) =
     var fut = newFuture[T]()
     fut.fail(newAsyncStreamUseClosedError())
     return fut
-
 
 template checkStreamFinished(t: untyped, T: type) =
   if t.atEof():
@@ -461,15 +449,6 @@ proc readLine*(rstream: AsyncStreamReader, limit = 0,
 
   rstream.vtbl.readLine(rstream, limit, sep)
 
-proc read*(rstream: AsyncStreamReader): Future[seq[byte]] {.
-     async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
-  ## Read all bytes from read-only stream ``rstream``.
-  ##
-  ## This procedure allocates buffer seq[byte] and return it as result.
-  checkStreamClosed(rstream, seq[byte])
-
-  rstream.vtbl.read(rstream)
-
 proc read*(rstream: AsyncStreamReader, n: int): Future[seq[byte]] {.
      async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
   ## Read all bytes (n <= 0) or exactly `n` bytes from read-only stream
@@ -480,14 +459,12 @@ proc read*(rstream: AsyncStreamReader, n: int): Future[seq[byte]] {.
 
   rstream.vtbl.readN(rstream, n)
 
-proc consume*(rstream: AsyncStreamReader): Future[int] {.
+proc read*(rstream: AsyncStreamReader): Future[seq[byte]] {.
      async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
-  ## Consume (discard) all bytes from read-only stream ``rstream``.
+  ## Read all bytes from read-only stream ``rstream``.
   ##
-  ## Return number of bytes actually consumed (discarded).
-  checkStreamClosed(rstream, int)
-
-  rstream.vtbl.consume(rstream)
+  ## This procedure allocates buffer seq[byte] and return it as result.
+  rstream.read(0)
 
 proc consume*(rstream: AsyncStreamReader, n: int): Future[int] {.
      async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
@@ -498,6 +475,13 @@ proc consume*(rstream: AsyncStreamReader, n: int): Future[int] {.
   checkStreamClosed(rstream, int)
 
   rstream.vtbl.consumeN(rstream, n)
+
+proc consume*(rstream: AsyncStreamReader): Future[int] {.
+     async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
+  ## Consume (discard) all bytes from read-only stream ``rstream``.
+  ##
+  ## Return number of bytes actually consumed (discarded).
+  rstream.consume(0)
 
 proc readMessage*(rstream: AsyncStreamReader, pred: ReadMessagePredicate) {.
      async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
@@ -527,9 +511,6 @@ proc write*(wstream: AsyncStreamWriter, pbytes: pointer,
   ## ``nbytes`` must be more then zero.
   checkStreamClosed(wstream, void)
   checkStreamFinished(wstream, void)
-
-  if nbytes <= 0:
-    raiseEmptyMessageDefect()
 
   wstream.vtbl.write(wstream, pbytes, nbytes)
 
@@ -575,40 +556,40 @@ proc join*(rw: AsyncStreamRW): Future[void] {.
   ## closed.
   rw.future.join()
 
-proc close*(rw: AsyncStreamReader) =
-  ## Close and frees resources of stream ``rw``.
+proc close*(rstream: AsyncStreamReader) =
+  ## Close and frees resources of stream ``rstream``.
   ##
   ## Note close() procedure is not completed immediately!
-  if not(rw.closed()):
-    rw.state = AsyncStreamState.Closing
+  if not(rstream.closed()):
+    rstream.state = AsyncStreamState.Closing
 
     proc continuation(udata: pointer) {.raises: [].} =
-      if not isNil(rw.udata):
-        GC_unref(cast[ref int](rw.udata))
-      if not(rw.future.finished()):
-        rw.future.complete()
+      if not isNil(rstream.udata):
+        GC_unref(cast[ref int](rstream.udata))
+      if not (rstream.future.finished()):
+        rstream.future.complete()
       untrackCounter(AsyncStreamReaderTrackerName)
-      rw.state = AsyncStreamState.Closed
+      rstream.state = AsyncStreamState.Closed
 
-    let fut = rw.vtbl.close(rw)
+    let fut = rstream.vtbl.close(rstream)
     fut.addCallback(continuation)
 
-proc close*(rw: AsyncStreamWriter) =
-  ## Close and frees resources of stream ``rw``.
+proc close*(wstream: AsyncStreamWriter) =
+  ## Close and frees resources of stream ``rstream``.
   ##
   ## Note close() procedure is not completed immediately!
-  if not(rw.closed()):
-    rw.state = AsyncStreamState.Closing
+  if not(wstream.closed()):
+    wstream.state = AsyncStreamState.Closing
 
     proc continuation(udata: pointer) {.raises: [].} =
-      if not isNil(rw.udata):
-        GC_unref(cast[ref int](rw.udata))
-      if not(rw.future.finished()):
-        rw.future.complete()
+      if not isNil(wstream.udata):
+        GC_unref(cast[ref int](wstream.udata))
+      if not (wstream.future.finished()):
+        wstream.future.complete()
       untrackCounter(AsyncStreamWriterTrackerName)
-      rw.state = AsyncStreamState.Closed
+      wstream.state = AsyncStreamState.Closed
 
-    let fut = rw.vtbl.close(rw)
+    let fut = wstream.vtbl.close(wstream)
     fut.addCallback(continuation)
 
 proc closeWait*(rw: AsyncStreamRW): Future[void] {.async: (raises: []).} =
@@ -616,16 +597,6 @@ proc closeWait*(rw: AsyncStreamRW): Future[void] {.async: (raises: []).} =
   if not rw.closed():
     rw.close()
     await noCancel(rw.join())
-
-proc startReader(rstream: AsyncStreamReader) =
-  rstream.state = Running
-  rstream.future = Future[void].Raising([]).init(
-    "async.stream.empty.reader", {FutureFlag.OwnCancelSchedule})
-
-proc startWriter(wstream: AsyncStreamWriter) =
-  wstream.state = Running
-  wstream.future = Future[void].Raising([]).init(
-    "async.stream.empty.writer", {FutureFlag.OwnCancelSchedule})
 
 proc init(T: type AsyncStreamReaderVtbl, rsource: AsyncStreamReader): T =
   # Trivial vtable that forwards all operations to another stream
@@ -661,24 +632,12 @@ proc init(T: type AsyncStreamReaderVtbl, rsource: AsyncStreamReader): T =
   ): Future[string] {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
     readLine(rsource, limit, sep)
 
-  proc readImpl(
-      rstream: AsyncStreamReader
-  ): Future[seq[byte]] {.
-      async: (raises: [CancelledError, AsyncStreamError], raw: true)
-  .} =
-    read(rsource)
-
   proc readNImpl(
       rstream: AsyncStreamReader, n: int
   ): Future[seq[byte]] {.
       async: (raises: [CancelledError, AsyncStreamError], raw: true)
   .} =
     read(rsource, n)
-
-  proc consumeImpl(
-      rstream: AsyncStreamReader
-  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
-    consume(rsource)
 
   proc consumeNImpl(
       rstream: AsyncStreamReader, n: int
@@ -690,9 +649,7 @@ proc init(T: type AsyncStreamReaderVtbl, rsource: AsyncStreamReader): T =
   ) {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
     readMessage(rsource, pred)
 
-  proc closeImpl(
-    rstream: AsyncStreamReader
-  ) {.async: (raises: []).} =
+  proc closeImpl(rstream: AsyncStreamReader) {.async: (raises: []).} =
     close(rsource)
 
   T(
@@ -700,13 +657,11 @@ proc init(T: type AsyncStreamReaderVtbl, rsource: AsyncStreamReader): T =
     stopped: stoppedImpl,
     running: runningImpl,
     failed: failedImpl,
-    readExactly: readExactlyImpl,
     readOnce: readOnceImpl,
+    readExactly: readExactlyImpl,
     readUntil: readUntilImpl,
     readLine: readLineImpl,
-    read: readImpl,
     readN: readNImpl,
-    consume: consumeImpl,
     consumeN: consumeNImpl,
     readMessage: readMessageImpl,
     close: closeImpl,
@@ -765,31 +720,11 @@ proc init(T: type AsyncStreamReaderVtbl, tsource: StreamTransport): T =
     except TransportError as exc:
       raise newAsyncStreamReadError(exc)
 
-  proc readImpl(
-      rstream: AsyncStreamReader
-  ): Future[seq[byte]] {.async: (raises: [CancelledError, AsyncStreamError]).} =
-    try:
-      return await read(tsource)
-    except TransportLimitError:
-      raise newAsyncStreamLimitError()
-    except TransportError as exc:
-      raise newAsyncStreamReadError(exc)
-
   proc readNImpl(
       rstream: AsyncStreamReader, n: int
   ): Future[seq[byte]] {.async: (raises: [CancelledError, AsyncStreamError]).} =
     try:
       return await read(tsource, n)
-    except TransportError as exc:
-      raise newAsyncStreamReadError(exc)
-
-  proc consumeImpl(
-      rstream: AsyncStreamReader
-  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
-    try:
-      return await consume(tsource)
-    except TransportLimitError:
-      raise newAsyncStreamLimitError()
     except TransportError as exc:
       raise newAsyncStreamReadError(exc)
 
@@ -811,9 +746,7 @@ proc init(T: type AsyncStreamReaderVtbl, tsource: StreamTransport): T =
     except TransportError as exc:
       raise newAsyncStreamReadError(exc)
 
-  proc closeImpl(
-    rstream: AsyncStreamReader
-  ) {.async: (raises: []).} =
+  proc closeImpl(rstream: AsyncStreamReader) {.async: (raises: []).} =
     discard # TODO cascade close?
 
   T(
@@ -821,13 +754,11 @@ proc init(T: type AsyncStreamReaderVtbl, tsource: StreamTransport): T =
     stopped: stoppedImpl,
     running: runningImpl,
     failed: failedImpl,
-    readExactly: readExactlyImpl,
     readOnce: readOnceImpl,
+    readExactly: readExactlyImpl,
     readUntil: readUntilImpl,
     readLine: readLineImpl,
-    read: readImpl,
     readN: readNImpl,
-    consume: consumeImpl,
     consumeN: consumeNImpl,
     readMessage: readMessageImpl,
     close: closeImpl,
@@ -864,38 +795,38 @@ proc init(
   proc readExactlyImpl(
       rstream: AsyncStreamReader, pbytes: pointer, nbytes: int
   ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
-      var
-        total = 0
-        pbuffer = cast[ptr byte](pbytes)
-      readLoop():
-        if len(rstream.buffer.backend) == 0:
-          if rstream.atEof():
-            raise newAsyncStreamIncompleteError()
-        let consumed =
-          rstream.buffer.backend.copyInto(pbuffer.makeOpenArray(nbytes - total))
-        pbuffer = pbuffer.offset(consumed)
-        total += consumed
-        (consumed: consumed, done: total == nbytes)
+    var
+      total = 0
+      pbuffer = cast[ptr byte](pbytes)
+    readLoop:
+      if len(rstream.buffer.backend) == 0:
+        if rstream.atEof():
+          raise newAsyncStreamIncompleteError()
+      let consumed =
+        rstream.buffer.backend.copyInto(pbuffer.makeOpenArray(nbytes - total))
+      pbuffer = pbuffer.offset(consumed)
+      total += consumed
+      (consumed: consumed, done: total == nbytes)
 
   proc readOnceImpl(
       rstream: AsyncStreamReader, pbytes: pointer, nbytes: int
   ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
-      var
-        total = 0
-        pbuffer = cast[ptr byte](pbytes)
-      readLoop():
-        if len(rstream.buffer.backend) == 0:
-          (0, rstream.atEof())
-        else:
-          total = rstream.buffer.backend.copyInto(pbuffer.makeOpenArray(nbytes))
-          (total, true)
-      total
+    var
+      total = 0
+      pbuffer = cast[ptr byte](pbytes)
+    readLoop:
+      if len(rstream.buffer.backend) == 0:
+        (0, rstream.atEof())
+      else:
+        total = rstream.buffer.backend.copyInto(pbuffer.makeOpenArray(nbytes))
+        (total, true)
+    total
 
   proc readUntilImpl(
       rstream: AsyncStreamReader, pbytes: pointer, nbytes: int, sep: seq[byte]
   ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
     var
-      pbuffer = pbytes.toUnchecked()
+      pbuffer = cast[ptr byte](pbytes).makeUncheckedArray()
       state = 0
       k = 0
     readLoop:
@@ -920,7 +851,7 @@ proc init(
       res = ""
       state = 0
 
-    readLoop():
+    readLoop:
       if rstream.atEof():
         (0, true)
       else:
@@ -928,63 +859,39 @@ proc init(
 
     res
 
-  proc readImpl(
-      rstream: AsyncStreamReader
-  ): Future[seq[byte]] {.async: (raises: [CancelledError, AsyncStreamError]).} =
-    var res: seq[byte]
-    readLoop():
-      if rstream.atEof():
-        (0, true)
-      else:
-        var pos = res.len
-        res.setLenUninit(pos + rstream.buffer.backend.len())
-        let bytesRead =
-          rstream.buffer.backend.copyInto(res.toOpenArray(pos, res.high()))
-        (bytesRead, false)
-    res
-
   proc readNImpl(
       rstream: AsyncStreamReader, n: int
   ): Future[seq[byte]] {.async: (raises: [CancelledError, AsyncStreamError]).} =
     var res = newSeq[byte]()
-    readLoop():
-      if rstream.atEof():
-        (0, true)
-      else:
-        var pos = res.len
-        res.setLenUninit(pos + min(rstream.buffer.backend.len(), n - res.len))
-        let bytesRead =
-          rstream.buffer.backend.copyInto(res.toOpenArray(pos, res.high()))
-        (bytesRead, len(res) == n)
-    res
-
-  proc consumeImpl(
-      rstream: AsyncStreamReader
-  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
-    var res = 0
     readLoop:
       if rstream.atEof():
         (0, true)
       else:
-        let used = len(rstream.buffer.backend)
-        res += used
-        (used, false)
+        let
+          pos = res.len
+          avail = len(rstream.buffer.backend)
+          newlen =
+            if n > 0:
+              min(avail, n - pos)
+            else:
+              avail
+        res.setLenUninit(pos + newlen)
+        let bytesRead =
+          rstream.buffer.backend.copyInto(res.toOpenArray(pos, res.high()))
+        (bytesRead, n > 0 and len(res) == n)
     res
 
   proc consumeNImpl(
       rstream: AsyncStreamReader, n: int
   ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
-    if n <= 0:
-      return await rstream.consume()
-    else:
-      var res = 0
-      readLoop:
-        let
-          used = len(rstream.buffer.backend)
-          count = min(used, n - res)
-        res += count
-        (count, res == n)
-      res
+    var res = 0
+    readLoop:
+      let
+        avail = len(rstream.buffer.backend)
+        count = if n > 0: min(avail, n - res) else: avail
+      res += count
+      (count, n > 0 and res == n)
+    res
 
   proc readMessageImpl(
       rstream: AsyncStreamReader, pred: ReadMessagePredicate
@@ -999,13 +906,11 @@ proc init(
       else:
         var res: tuple[consumed: int, done: bool]
         for (region, rsize) in rstream.buffer.backend.regions():
-          res = pred(region.toUnchecked().toOpenArray(0, rsize - 1))
+          res = pred(region.makeOpenArray(rsize))
           break
         res
 
-  proc closeImpl(
-    rstream: AsyncStreamReader
-  ) {.async: (raises: [], raw: true).} =
+  proc closeImpl(_: AsyncStreamReader) {.async: (raises: [], raw: true).} =
     readerLoopFut.cancelAndWait()
 
   T(
@@ -1013,46 +918,42 @@ proc init(
     stopped: stoppedImpl,
     running: runningImpl,
     failed: failedImpl,
-    readExactly: readExactlyImpl,
     readOnce: readOnceImpl,
+    readExactly: readExactlyImpl,
     readUntil: readUntilImpl,
     readLine: readLineImpl,
-    read: readImpl,
     readN: readNImpl,
-    consume: consumeImpl,
     consumeN: consumeNImpl,
     readMessage: readMessageImpl,
     close: closeImpl,
   )
 
 proc init(T: type AsyncStreamWriterVtbl, wsource: AsyncStreamWriter): T =
-  proc atEofImpl(wstream: AsyncStreamWriter): bool =
+  proc atEofImpl(_: AsyncStreamWriter): bool =
     wsource.atEof()
 
-  proc stoppedImpl(rw: AsyncStreamWriter): bool =
+  proc stoppedImpl(_: AsyncStreamWriter): bool =
     wsource.stopped()
 
-  proc runningImpl(rw: AsyncStreamWriter): bool =
+  proc runningImpl(_: AsyncStreamWriter): bool =
     ## Returns ``true`` if reading/writing stream is still pending.
     wsource.running()
 
-  proc failedImpl(rw: AsyncStreamWriter): bool =
+  proc failedImpl(_: AsyncStreamWriter): bool =
     ## Returns ``true`` if reading/writing stream is in failed state.
     wsource.failed()
 
   proc writeImpl(
-      wstream: AsyncStreamWriter, pbytes: pointer, nbytes: int
+      _: AsyncStreamWriter, pbytes: pointer, nbytes: int
   ) {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
     write(wsource, pbytes, nbytes)
 
   proc finishImpl(
-      wstream: AsyncStreamWriter
+      _: AsyncStreamWriter
   ) {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
     wsource.finish()
 
-  proc closeImpl(
-      wstream: AsyncStreamWriter
-  ) {.async: (raises: []).} =
+  proc closeImpl(_: AsyncStreamWriter) {.async: (raises: []).} =
     wsource.close()
 
   AsyncStreamWriterVtbl(
@@ -1066,20 +967,20 @@ proc init(T: type AsyncStreamWriterVtbl, wsource: AsyncStreamWriter): T =
   )
 
 proc init(T: type AsyncStreamWriterVtbl, tsource: StreamTransport): T =
-  proc atEofImpl(wstream: AsyncStreamWriter): bool =
+  proc atEofImpl(_: AsyncStreamWriter): bool =
     tsource.atEof()
 
-  proc stoppedImpl(rw: AsyncStreamWriter): bool =
+  proc stoppedImpl(_: AsyncStreamWriter): bool =
     false
 
-  proc runningImpl(rw: AsyncStreamWriter): bool =
+  proc runningImpl(_: AsyncStreamWriter): bool =
     tsource.running()
 
-  proc failedImpl(rw: AsyncStreamWriter): bool =
+  proc failedImpl(_: AsyncStreamWriter): bool =
     tsource.failed()
 
   proc writeImpl(
-      wstream: AsyncStreamWriter, pbytes: pointer, nbytes: int
+      _: AsyncStreamWriter, pbytes: pointer, nbytes: int
   ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
     let res =
       try:
@@ -1090,13 +991,11 @@ proc init(T: type AsyncStreamWriterVtbl, tsource: StreamTransport): T =
       raise newAsyncStreamIncompleteError()
 
   proc finishImpl(
-      wstream: AsyncStreamWriter
+      _: AsyncStreamWriter
   ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
     discard # TODO shutdown?
 
-  proc closeImpl(
-      wstream: AsyncStreamWriter
-  ) {.async: (raises: []).} =
+  proc closeImpl(_: AsyncStreamWriter) {.async: (raises: []).} =
     discard
 
   T(
@@ -1121,23 +1020,23 @@ proc init(
     else:
       wstream.state != AsyncStreamState.Running
 
-  proc stoppedImpl(rw: AsyncStreamWriter): bool =
-    if isNil(rw.future) or rw.future.finished():
+  proc stoppedImpl(wstream: AsyncStreamWriter): bool =
+    if isNil(wstream.future) or wstream.future.finished():
       false
     else:
-      rw.state == AsyncStreamState.Stopped
+      wstream.state == AsyncStreamState.Stopped
 
-  proc runningImpl(rw: AsyncStreamWriter): bool =
-    if isNil(rw.future) or rw.future.finished():
+  proc runningImpl(wstream: AsyncStreamWriter): bool =
+    if isNil(wstream.future) or wstream.future.finished():
       false
     else:
-      rw.state == AsyncStreamState.Running
+      wstream.state == AsyncStreamState.Running
 
-  proc failedImpl(rw: AsyncStreamWriter): bool =
-    if isNil(rw.future) or rw.future.finished():
+  proc failedImpl(wstream: AsyncStreamWriter): bool =
+    if isNil(wstream.future) or wstream.future.finished():
       false
     else:
-      rw.state == AsyncStreamState.Error
+      wstream.state == AsyncStreamState.Error
 
   proc writeImpl(
       wstream: AsyncStreamWriter, pbytes: pointer, nbytes: int
@@ -1168,9 +1067,7 @@ proc init(
       await wstream.queue.put(item)
     await item.future
 
-  proc closeImpl(
-      wstream: AsyncStreamWriter
-  ) {.async: (raises: [], raw: true).} =
+  proc closeImpl(_: AsyncStreamWriter) {.async: (raises: [], raw: true).} =
     writerLoopFut.cancelAndWait()
 
   T(
@@ -1180,20 +1077,23 @@ proc init(
     failed: failedImpl,
     write: writeImpl,
     finish: finishImpl,
-    close: closeImpl
+    close: closeImpl,
   )
 
-proc initUdata*[T](child: AsyncStreamRW, udata: ref T) =
+proc initUdata*[T](rw: AsyncStreamRW, udata: ref T) =
   if not isNil(udata):
     GC_ref(udata)
-    child.udata = cast[pointer](udata)
+    rw.udata = cast[pointer](udata)
 
-proc init*(child: AsyncStreamWriter, vtbl: AsyncStreamWriterVtbl) =
-  ## Initialize newly allocated object ``child`` with AsyncStreamWriter
+proc init*(wstream: AsyncStreamWriter, vtbl: AsyncStreamWriterVtbl) =
+  ## Initialize newly allocated object ``wstream`` with AsyncStreamWriter
   ## parameters.
   trackCounter(AsyncStreamWriterTrackerName)
-  child.startWriter()
-  child.vtbl = vtbl
+  wstream.state = AsyncStreamState.Running
+  wstream.future = Future[void].Raising([]).init(
+      "async.stream.empty.writer", {FutureFlag.OwnCancelSchedule}
+    )
+  wstream.vtbl = vtbl
 
 proc init*(child, wsource: AsyncStreamWriter, loop: StreamWriterLoop,
            queueSize = AsyncStreamDefaultQueueSize) {.deprecated: "initSimpleVtbl".} =
@@ -1216,12 +1116,15 @@ proc init*[T](child, wsource: AsyncStreamWriter, loop: StreamWriterLoop,
   child.initUdata(udata)
   child.init(child, wsource, loop, queueSize)
 
-proc init*(child: AsyncStreamReader, vtbl: AsyncStreamReaderVtbl) =
-  ## Initialize newly allocated object ``child`` with AsyncStreamReader
+proc init*(rstream: AsyncStreamReader, vtbl: AsyncStreamReaderVtbl) =
+  ## Initialize newly allocated object ``rstream`` with AsyncStreamReader
   ## parameters.
   trackCounter(AsyncStreamReaderTrackerName)
-  child.startReader()
-  child.vtbl = vtbl
+  rstream.state = Running
+  rstream.future = Future[void].Raising([]).init(
+      "async.stream.empty.reader", {FutureFlag.OwnCancelSchedule}
+    )
+  rstream.vtbl = vtbl
 
 proc init*(child, rsource: AsyncStreamReader, loop: StreamReaderLoop,
            bufferSize = AsyncStreamDefaultBufferSize) {.deprecated: "initSimpleVtbl".} =
@@ -1471,18 +1374,18 @@ proc initSimpleVtbl*(
     while true:
       if len(rstream.buffer.backend) == 0:
         case rstream.state
-        of Running:
+        of AsyncStreamState.Running:
           let (data, size) = rstream.buffer.backend.reserve()
           rstream.buffer.backend.commit(await readOnceImpl(rstream, data, size))
-        of Error:
+        of AsyncStreamState.Error:
           let fut = newFuture[int]()
           fut.fail(rstream.error)
           return fut
-        of Finished:
+        of AsyncStreamState.Finished:
           let fut = newFuture[int]()
           fut.complete(0)
           return fut
-        of Stopped, Closing, Closed:
+        of AsyncStreamState.Stopped, AsyncStreamState.Closing, AsyncStreamState.Closed:
           let fut = newFuture[int]()
           fut.fail(newAsyncStreamUseClosedError())
           return fut
@@ -1496,27 +1399,30 @@ proc initSimpleVtbl*(
       rstream: AsyncStreamReader, pbytes: pointer, nbytes: int
   ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
     case rstream.state
-    of Running:
+    of AsyncStreamState.Running:
       readOnceImpl(rstream, pbytes, nbytes)
-    of Error:
+    of AsyncStreamState.Error:
       let fut = newFuture[int]()
       fut.fail(rstream.error)
       fut
-    of Finished:
+    of AsyncStreamState.Finished:
       let fut = newFuture[int]()
       fut.complete(0)
       fut
-    of Stopped, Closing, Closed:
+    of AsyncStreamState.Stopped, AsyncStreamState.Closing, AsyncStreamState.Closed:
       let fut = newFuture[int]()
       fut.fail(newAsyncStreamUseClosedError())
       fut
 
   proc atEofImpl(rstream: AsyncStreamReader): bool =
     rstream.state != AsyncStreamState.Running
+
   proc stoppedImpl(rstream: AsyncStreamReader): bool =
     rstream.state == AsyncStreamState.Stopped
+
   proc runningImpl(rstream: AsyncStreamReader): bool =
     rstream.state == AsyncStreamState.Running
+
   proc failedImpl(rstream: AsyncStreamReader): bool =
     rstream.state == AsyncStreamState.Error
 
@@ -1538,7 +1444,7 @@ proc initSimpleVtbl*(
       rstream: AsyncStreamReader, pbytes: pointer, nbytes: int, sep: seq[byte]
   ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
     var
-      pbuffer = pbytes.toUnchecked()
+      pbuffer = cast[ptr byte](pbytes).makeUncheckedArray()
       state = 0
       k = 0
     rstream.bufferedLoop:
@@ -1601,11 +1507,6 @@ proc initSimpleVtbl*(
     # TODO https://github.com/nim-lang/Nim/issues/25057
     move(res)
 
-  proc readImpl(
-      rstream: AsyncStreamReader
-  ): Future[seq[byte]] {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
-    readNImpl(rstream, 0)
-
   proc consumeNImpl(
       rstream: AsyncStreamReader, n: int
   ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError]).} =
@@ -1622,11 +1523,6 @@ proc initSimpleVtbl*(
 
     res
 
-  proc consumeImpl(
-      rstream: AsyncStreamReader
-  ): Future[int] {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
-    consumeNImpl(rstream, 0)
-
   proc readMessageImpl(
       rstream: AsyncStreamReader, pred: ReadMessagePredicate
   ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
@@ -1636,7 +1532,7 @@ proc initSimpleVtbl*(
       else:
         var res: tuple[consumed: int, done: bool]
         for (region, rsize) in rstream.buffer.backend.regions:
-          res = pred(region.toUnchecked().toOpenArray(0, rsize - 1))
+          res = pred(region.makeOpenArray(rsize))
           break
         res
 
@@ -1648,33 +1544,29 @@ proc initSimpleVtbl*(
     stopped: stoppedImpl,
     running: runningImpl,
     failed: failedImpl,
-    readExactly: readExactlyImpl,
     readOnce: readOnceImplWrapper,
+    readExactly: readExactlyImpl,
     readUntil: readUntilImpl,
     readLine: readLineImpl,
-    read: readImpl,
     readN: readNImpl,
-    consume: consumeImpl,
     consumeN: consumeNImpl,
     readMessage: readMessageImpl,
     close: closeImpl,
   )
 
-proc initSimpleVtbl*(
-    T: type AsyncStreamWriterVtbl,
-    writeImpl: WriteProc,
-): T =
+proc initSimpleVtbl*(T: type AsyncStreamWriterVtbl, writeImpl: WriteProc): T =
   proc writeImplWrapper(
       wstream: AsyncStreamWriter, pbytes: pointer, nbytes: int
   ) {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
     case wstream.state
-    of Running:
+    of AsyncStreamState.Running:
       writeImpl(wstream, pbytes, nbytes)
-    of Error:
+    of AsyncStreamState.Error:
       let fut = newFuture[void]()
       fut.fail(wstream.error)
       fut
-    of Stopped, Finished, Closing, Closed:
+    of AsyncStreamState.Stopped, AsyncStreamState.Finished, AsyncStreamState.Closing,
+        AsyncStreamState.Closed:
       let fut = newFuture[void]()
       fut.fail(newAsyncStreamUseClosedError())
       fut

--- a/chronos/streams/boundstream.nim
+++ b/chronos/streams/boundstream.nim
@@ -209,13 +209,7 @@ proc initReaderVtbl(bufferSize: int): AsyncStreamReaderVtbl =
     else:
       readNOrig(rstream, n)
 
-  proc readImpl(
-      rstream: AsyncStreamReader
-  ): Future[seq[byte]] {.async: (raises: [CancelledError, AsyncStreamError], raw: true).} =
-    readNImpl(rstream, 0)
-
   res.readN = readNImpl
-  res.read = readImpl
 
   res
 

--- a/chronos/streams/chunkstream.nim
+++ b/chronos/streams/chunkstream.nim
@@ -222,6 +222,9 @@ proc write(
     nbytes: int,
 ) {.async: (raises: [CancelledError, AsyncStreamError]).} =
   await wstream.lock.acquire() # Avoid interleaving writes
+  if nbytes == 0: # avoid sending zero-length chunk, aka "end-of-transfer"
+    return
+
   try:
     var buffer: array[16, byte]
 

--- a/chronos/transports/common.nim
+++ b/chronos/transports/common.nim
@@ -57,7 +57,7 @@ type
     Pause,                        # Pause server
     Stop                          # Stop server
 
-  ServerStatus* = enum
+  ServerStatus* {.pure.} = enum
     ## Server's statuses
     Starting,                     # Server created
     Stopped,                      # Server stopped
@@ -576,7 +576,7 @@ template checkClosed*(t: untyped, future: untyped) =
     return future
 
 template checkWriteEof*(t: untyped, future: untyped) =
-  if (WriteEof in (t).state):
+  if (TransportState.WriteEof in (t).state):
     future.fail(newException(TransportUseEofError,
                              "Transport connection is already dropped!"))
     return future

--- a/chronos/transports/stream.nim
+++ b/chronos/transports/stream.nim
@@ -226,17 +226,17 @@ template shiftVectorFile(v: var StreamVector, o: untyped) =
 
 proc completePendingWriteQueue(queue: var Deque[StreamVector],
                                v: int) {.inline.} =
-  while len(queue) > 0:
-    var vector = queue.popFirst()
+  for vector in queue:
     if not(vector.writer.finished()):
       vector.writer.complete(v)
+  queue.reset()
 
 proc failPendingWriteQueue(queue: var Deque[StreamVector],
                            error: ref TransportError) {.inline.} =
-  while len(queue) > 0:
-    var vector = queue.popFirst()
+  for vector in queue:
     if not(vector.writer.finished()):
       vector.writer.fail(error)
+  queue.reset()
 
 proc clean(server: StreamServer) {.inline.} =
   if not(server.loopFuture.finished()):
@@ -251,9 +251,6 @@ proc clean(transp: StreamTransport) {.inline.} =
     untrackCounter(StreamTransportTrackerName)
     transp.future.complete()
     GC_unref(transp)
-
-template toUnchecked*(a: untyped): untyped =
-  cast[ptr UncheckedArray[byte]](a)
 
 func getTransportFlags(server: StreamServer): set[TransportFlags] =
   if ServerFlags.V4Mapped in server.flags:
@@ -347,28 +344,19 @@ when defined(windows):
           of ERROR_OPERATION_ABORTED:
             # CancelIO() interrupt
             transp.state.incl({WritePaused, WriteEof})
-            let vector = transp.queue.popFirst()
-            if not(vector.writer.finished()):
-              vector.writer.complete(0)
             completePendingWriteQueue(transp.queue, 0)
             break
           else:
-            let vector = transp.queue.popFirst()
             if isConnResetError(err):
               # Soft error happens which indicates that remote peer got
               # disconnected, complete all pending writes in queue with 0.
               transp.state.incl({WritePaused, WriteEof})
-              if not(vector.writer.finished()):
-                vector.writer.complete(0)
               completePendingWriteQueue(transp.queue, 0)
-              break
             else:
               transp.state.incl({WritePaused, WriteError})
               let error = getTransportOsError(err)
-              if not(vector.writer.finished()):
-                vector.writer.fail(error)
               failPendingWriteQueue(transp.queue, error)
-              break
+            break
         else:
           ## Initiation
           transp.state.incl(WritePending)
@@ -711,16 +699,11 @@ when defined(windows):
       var
         saddr: Sockaddr_storage
         slen: SockLen
-        sock: AsyncFD
-        povl: RefCustomOverlapped
-        proto: Protocol
-
-      var raddress = anyAddressFix(address)
+        raddress = anyAddressFix(address)
 
       toSAddr(raddress, saddr, slen)
-      proto = Protocol.IPPROTO_TCP
-      sock = createAsyncSocket2(raddress.getDomain(), SockType.SOCK_STREAM,
-                                proto).valueOr:
+      let sock = createAsyncSocket2(raddress.getDomain(), SockType.SOCK_STREAM,
+                                    Protocol.IPPROTO_TCP).valueOr:
         retFuture.fail(getTransportOsError(error))
         return retFuture
 
@@ -799,10 +782,10 @@ when defined(windows):
             retFuture.fail(getTransportOsError(ovl.data.errCode))
         GC_unref(ovl)
 
-      proc cancel(udata: pointer) {.gcsafe.} =
+      retFuture.cancelCallback = proc(udata: pointer) {.gcsafe.} =
         sock.closeSocket()
 
-      povl = RefCustomOverlapped()
+      let povl = RefCustomOverlapped()
       GC_ref(povl)
       povl.data = CompletionData(cb: socketContinuation)
       let res = loop.connectEx(SocketHandle(sock),
@@ -819,8 +802,6 @@ when defined(windows):
           GC_unref(povl)
           sock.closeSocket()
           retFuture.fail(getTransportOsError(err))
-
-      retFuture.cancelCallback = cancel
 
     elif address.family == AddressFamily.Unix:
       ## Unix domain socket emulation with Windows Named Pipes.
@@ -853,9 +834,8 @@ when defined(windows):
             else:
               retFuture.fail(getTransportOsError(err))
           else:
-            let res = register2(AsyncFD(pipeHandle))
-            if res.isErr():
-              retFuture.fail(getTransportOsError(res.error()))
+            register2(AsyncFD(pipeHandle)).isOkOr:
+              retFuture.fail(getTransportOsError(error))
               return
 
             let transp = newStreamPipeTransport(AsyncFD(pipeHandle),
@@ -1274,12 +1254,12 @@ when defined(windows):
       if res == FALSE:
         let err = osLastError()
         case err
+        of ERROR_IO_PENDING:
+          discard
         of ERROR_OPERATION_ABORTED:
           server.apending = false
           retFuture.fail(getServerUseClosedError())
           return retFuture
-        of ERROR_IO_PENDING:
-          discard
         of WSAECONNRESET, WSAECONNABORTED, WSAENETDOWN,
            WSAENETRESET, WSAETIMEDOUT:
           server.apending = false
@@ -1312,12 +1292,12 @@ when defined(windows):
       if res == 0:
         let err = osLastError()
         case err
+        of ERROR_IO_PENDING, ERROR_PIPE_CONNECTED:
+          discard
         of ERROR_OPERATION_ABORTED:
           server.apending = false
           retFuture.fail(getServerUseClosedError())
           return retFuture
-        of ERROR_IO_PENDING, ERROR_PIPE_CONNECTED:
-          discard
         else:
           server.apending = false
           retFuture.fail(getTransportOsError(err))
@@ -1566,26 +1546,25 @@ else:
     var
       saddr: Sockaddr_storage
       slen: SockLen
-    var retFuture = newFuture[StreamTransport]("stream.transport.connect")
-
-    var raddress = anyAddressFix(address)
-    toSAddr(raddress, saddr, slen)
+      raddress = anyAddressFix(address)
     raddress.toSAddr(saddr, slen)
 
-    let proto =
-      if raddress.family == AddressFamily.Unix:
-        Protocol.IPPROTO_IP
-      else:
-        Protocol.IPPROTO_TCP
+    let
+      retFuture = newFuture[StreamTransport]("stream.transport.connect")
+      proto =
+        if raddress.family == AddressFamily.Unix:
+          Protocol.IPPROTO_IP
+        else:
+          Protocol.IPPROTO_TCP
 
-    let sock = createAsyncSocket2(raddress.getDomain(), SockType.SOCK_STREAM,
-                                  proto).valueOr:
-      case error
-      of oserrno.EMFILE:
-        retFuture.fail(getTransportTooManyError())
-      else:
-        retFuture.fail(getTransportOsError(error))
-      return retFuture
+      sock = createAsyncSocket2(raddress.getDomain(), SockType.SOCK_STREAM,
+                                proto).valueOr:
+        case error
+        of oserrno.EMFILE:
+          retFuture.fail(getTransportTooManyError())
+        else:
+          retFuture.fail(getTransportOsError(error))
+        return retFuture
 
     if raddress.family in {AddressFamily.IPv4, AddressFamily.IPv6}:
       if SocketFlags.TcpNoDelay in flags:
@@ -1702,12 +1681,13 @@ else:
       # it could have been released
       return
 
-    var
-      saddr: Sockaddr_storage
-      slen: SockLen
     let server = cast[StreamServer](udata)
     if server.status in {ServerStatus.Stopped, ServerStatus.Closed}:
       return
+
+    var
+      saddr: Sockaddr_storage
+      slen: SockLen
 
     let
       flags = {DescriptorFlag.CloseOnExec, DescriptorFlag.NonBlock}
@@ -2402,7 +2382,11 @@ template fastWrite(transp: auto, pbytes: var ptr byte, rbytes: var int,
 
   when not defined(windows) and not defined(nimdoc):
     if transp.queue.len == 0:
-      while rbytes > 0:
+      while true:
+        if rbytes == 0:
+          retFuture.complete(nbytes)
+          return retFuture
+
         let res =
           case transp.kind
           of TransportKind.Socket:
@@ -2415,11 +2399,6 @@ template fastWrite(transp: auto, pbytes: var ptr byte, rbytes: var int,
         if res > 0:
           pbytes = pbytes.offset(res)
           rbytes -= res
-
-          if rbytes == 0:
-            retFuture.complete(nbytes)
-            return retFuture
-          # Not all bytes written - keep going
         else:
           let err = osLastError()
           if isWouldBlockError(err):
@@ -2693,7 +2672,7 @@ proc readUntil*(transp: StreamTransport, pbytes: pointer, nbytes: int,
     raise newException(TransportLimitError, "Limit reached!")
 
   var
-    pbuffer = pbytes.toUnchecked()
+    pbuffer = cast[ptr byte](pbytes).makeUncheckedArray()
     state = 0
     k = 0
 
@@ -2754,7 +2733,7 @@ proc read*(transp: StreamTransport): Future[seq[byte]] {.
 
 proc read*(transp: StreamTransport, n: int): Future[seq[byte]] {.
     async: (raises: [TransportError, CancelledError]).} =
-  ## Read all bytes (n <= 0) or exactly `n` bytes from transport ``transp``.
+  ## Read all bytes (n <= 0) or up to `n` bytes from transport ``transp``.
   ##
   ## This procedure allocates buffer seq[byte] and return it as result.
   if n <= 0:
@@ -2832,7 +2811,7 @@ proc readMessage*(transp: StreamTransport,
     else:
       var res: tuple[consumed: int, done: bool]
       for (region, rsize) in transp.buffer.regions():
-        res = predicate(region.toUnchecked().toOpenArray(0, rsize - 1))
+        res = predicate(region.makeOpenArray(rsize ))
         break
       res
 


### PR DESCRIPTION
* allow and more consistently handle zero-byte writes across stream/transport
* remove redundant `read`/`consume` from stream vtable
* remove `toUnchecked` untyped template (not part of transport interface!)
* make `AsyncStreamState` pure
* reset stream queue when done (releases memory a little earlier)
* fix cancel callback defect on some windows accept errors
* fix docs for `read(n)` (we'll read fewer than `n` bytes in case of EOF)