### PR TITLE
fix: don't sleep/block if ticks are outstanding

### DIFF
--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -113,13 +113,15 @@ template processTimersGetTimeout(loop, timeout: untyped) =
     timeout = (lastFinish - curTime).getAsyncTimestamp()
 
   if timeout == 0:
-    if (len(loop.callbacks) == 0) and (len(loop.idlers) == 0):
+    if (len(loop.callbacks) == 0) and (len(loop.idlers) == 0) and
+        (len(loop.ticks) == 0):
       when defined(windows):
         timeout = INFINITE
       else:
         timeout = -1
   else:
-    if (len(loop.callbacks) != 0) or (len(loop.idlers) != 0):
+    if (len(loop.callbacks) != 0) or (len(loop.idlers) != 0) or
+        (len(loop.ticks) != 0):
       timeout = 0
 
 template processTimers(loop: untyped) =

--- a/tests/testtime.nim
+++ b/tests/testtime.nim
@@ -8,6 +8,7 @@
 import std/os
 import unittest2
 import ../chronos, ../chronos/timer
+import ../chronos/timer
 
 {.used.}
 
@@ -127,3 +128,34 @@ suite "Asynchronous timers & steps test suite":
 
     check:
       fut3.completed() == true
+
+  test "Cancellation retry tick does not wait for next timer":
+    const NextTimerSleep = 50.milliseconds
+
+    let gate = newFuture[void]("cancelAndWait.gate")
+    var
+      slept = false
+      workerFut: Future[void]
+
+    proc cancelWorker(): Future[void] {.async.} =
+      await gate
+      await workerFut.cancelAndWait()
+
+    proc worker() {.async.} =
+      try:
+        await gate
+        await sleepAsync(NextTimerSleep)
+        slept = true
+      except CancelledError:
+        discard
+
+    let cancelFut = cancelWorker()
+    workerFut = worker()
+    gate.complete()
+
+    while not cancelFut.finished:
+      poll()
+
+    check:
+      workerFut.finished
+      not slept

--- a/tests/testtime.nim
+++ b/tests/testtime.nim
@@ -130,7 +130,7 @@ suite "Asynchronous timers & steps test suite":
       fut3.completed() == true
 
   test "Cancellation retry tick does not wait for next timer":
-    const NextTimerSleep = 50.milliseconds
+    const NextTimerSleep = 500.milliseconds
 
     let gate = newFuture[void]("cancelAndWait.gate")
     var


### PR DESCRIPTION
Prevent `poll()` from blocking when internal `ticks` are outstanding.

When `cancelSoon()` fails to deliver cancellation on the first try, it installs a `tick` callback. However, `poll()` ignores `ticks` when calculating the current timeout. If a long timeout is scheduled, `poll()` can block until that timeout expires or IO wakes up the loop.

Treat `tick` callbacks as outstanding work when calculating the current `poll()` timeout.
