### PR TITLE
docs(asyncengine): add contains stub to nimdoc branch

### DIFF
--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -193,6 +193,7 @@ when defined(nimdoc):
   proc closeHandle*(fd: AsyncFD, aftercb: CallbackFunc = nil) = discard
   proc closeSocket*(fd: AsyncFD, aftercb: CallbackFunc = nil) = discard
   proc unregisterAndCloseFd*(fd: AsyncFD): Result[void, OSErrorCode] = discard
+  proc contains*(disp: PDispatcher, fd: AsyncFD): bool = discard
 
   proc `==`*(x: AsyncFD, y: AsyncFD): bool {.borrow, gcsafe.}
 


### PR DESCRIPTION
The `when defined(nimdoc)` stub branch omitted `contains`, which threadsync.nim calls via `loop.contains(fd)`, so `nim doc` fails for modules importing chronos/threadsync.