### PR TITLE
async: smaller codegen for `return`/`fail`/`complete`

### DIFF
--- a/chronos/internal/asyncfutures.nim
+++ b/chronos/internal/asyncfutures.nim
@@ -176,10 +176,9 @@ proc checkFinished(future: FutureBase, loc: ptr SrcLoc) =
   else:
     future.internalLocation[LocationKind.Finish] = loc
 
-proc finish(fut: FutureBase, state: FutureState) =
-  # We do not perform any checks here, because:
-  # 1. `finish()` is a private procedure and `state` is under our control.
-  # 2. `fut.state` is checked by `checkFinished()`.
+proc finish(fut: FutureBase, state: FutureState, loc: ptr SrcLoc) =
+  fut.checkFinished(loc)
+
   fut.internalState = state
   fut.internalCancelcb = nil # release cancellation callback memory
 
@@ -197,10 +196,8 @@ proc finish(fut: FutureBase, state: FutureState) =
 
 proc complete[T: not void](future: Future[T], val: chronosSink T, loc: ptr SrcLoc) =
   if not(future.cancelled()):
-    checkFinished(future, loc)
-    doAssert(isNil(future.internalError))
     future.internalValue = chronosMoveSink(val)
-    future.finish(FutureState.Completed)
+    future.finish(FutureState.Completed, loc)
 
 template complete*[T: not void](future: Future[T], val: chronosSink T) =
   ## Completes ``future`` with value ``val``.
@@ -208,9 +205,7 @@ template complete*[T: not void](future: Future[T], val: chronosSink T) =
 
 proc complete(future: Future[void], loc: ptr SrcLoc) =
   if not(future.cancelled()):
-    checkFinished(future, loc)
-    doAssert(isNil(future.internalError))
-    future.finish(FutureState.Completed)
+    future.finish(FutureState.Completed, loc)
 
 template complete*(future: Future[void]) =
   ## Completes a void ``future``.
@@ -219,14 +214,17 @@ template complete*(future: Future[void]) =
 proc failImpl(
     future: FutureBase, error: ref CatchableError, loc: ptr SrcLoc) =
   if not(future.cancelled()):
-    checkFinished(future, loc)
     future.internalError = error
     when chronosStackTrace:
       future.internalErrorStackTrace = if getStackTrace(error) == "":
                                  getStackTrace()
                                else:
                                  getStackTrace(error)
-    future.finish(FutureState.Failed)
+    future.finish(FutureState.Failed, loc)
+
+template internalFail*(future: FutureBase, error: ref CatchableError) =
+  # Version used by asyncmacro that doesn't need to perform `raises` validation
+  failImpl(future, error, getSrcLocation())
 
 template fail*[T](
     future: Future[T], error: ref CatchableError, warn: static bool = false) =
@@ -249,11 +247,10 @@ template newCancelledError(): ref CancelledError =
 
 proc cancelAndSchedule(future: FutureBase, loc: ptr SrcLoc) =
   if not(future.finished()):
-    checkFinished(future, loc)
     future.internalError = newCancelledError()
     when chronosStackTrace:
       future.internalErrorStackTrace = getStackTrace()
-    future.finish(FutureState.Cancelled)
+    future.finish(FutureState.Cancelled, loc)
 
 template cancelAndSchedule*(future: FutureBase) =
   cancelAndSchedule(future, getSrcLocation())

--- a/chronos/internal/asyncmacro.nim
+++ b/chronos/internal/asyncmacro.nim
@@ -13,21 +13,21 @@ import
   ../[futures, config],
   ./raisesfutures
 
-proc processBody(node, setResultSym: NimNode): NimNode {.compileTime.} =
+proc processBody(node, setResultSym: NimNode): (NimNode, bool) {.compileTime.} =
   case node.kind
   of nnkReturnStmt:
     # `return ...` -> `setResult(...); return`
     let
       res = newNimNode(nnkStmtList, node)
     if node[0].kind != nnkEmpty:
-      res.add newCall(setResultSym, processBody(node[0], setResultSym))
+      res.add newCall(setResultSym, processBody(node[0], setResultSym)[0])
     res.add newNimNode(nnkReturnStmt, node).add(newEmptyNode())
 
-    res
+    (res, node[0].kind != nnkEmpty)
   of RoutineNodes-{nnkTemplateDef}:
     # Skip nested routines since they have their own return value distinct from
     # the Future we inject
-    node
+    (node, false)
   else:
     if node.kind == nnkYieldStmt:
       # asyncdispatch allows `yield` but this breaks cancellation
@@ -35,12 +35,15 @@ proc processBody(node, setResultSym: NimNode): NimNode {.compileTime.} =
         "`yield` in async procedures not supported - use `awaitne` instead",
         node)
 
+    var anyUsed = false
     for i in 0 ..< node.len:
-      node[i] = processBody(node[i], setResultSym)
-    node
+      let (child, used) = processBody(node[i], setResultSym)
+      node[i] = child
+      anyUsed = used or anyUsed
+    (node, anyUsed)
 
 proc wrapInTryFinally(
-  fut, baseType, body, raises: NimNode,
+  fut, castFut, baseType, body, raises: NimNode,
   handleException: bool): NimNode {.compileTime.} =
   # creates:
   # try: `body`
@@ -97,7 +100,7 @@ proc wrapInTryFinally(
                 nnkInfix.newTree(ident"as", ident"CatchableError", excName),
                 nnkStmtList.newTree(
                   nnkAsgn.newTree(closureSucceeded, ident"false"),
-                  newCall(ident "fail", fut, excName)
+                  newCall(ident "internalFail", fut, excName)
                 ))
 
   var raises = if raises == nil:
@@ -117,10 +120,10 @@ proc wrapInTryFinally(
       addDefect
 
       # Because we store `CatchableError` in the Future, we cannot re-raise the
-      # original exception
+      # original Exception
       nTry.add nnkExceptBranch.newTree(
                 nnkInfix.newTree(ident"as", ident"Exception", excName),
-                newCall(ident "fail", fut,
+                newCall(ident "internalFail", fut,
                   nnkStmtList.newTree(
                     nnkAsgn.newTree(closureSucceeded, ident"false"),
                   quote do:
@@ -139,7 +142,7 @@ proc wrapInTryFinally(
                 nnkInfix.newTree(ident"as", exc, excName),
                 nnkStmtList.newTree(
                   nnkAsgn.newTree(closureSucceeded, ident"false"),
-                  newCall(ident "fail", fut, excName)
+                  newCall(ident "internalFail", fut, excName)
                 ))
 
   addDefect # Must not complete future on defect
@@ -149,15 +152,15 @@ proc wrapInTryFinally(
       nnkElifBranch.newTree(
         closureSucceeded,
         if baseType.eqIdent("void"): # shortcut for non-generic void
-          newCall(ident "complete", fut)
+          newCall(ident "complete", castFut)
         else:
           nnkWhenStmt.newTree(
             nnkElifExpr.newTree(
               nnkInfix.newTree(ident "is", baseType, ident "void"),
-              newCall(ident "complete", fut)
+              newCall(ident "complete", castFut)
             ),
             nnkElseExpr.newTree(
-              newCall(ident "complete", fut, newCall(ident "move", ident "result"))
+              newCall(ident "complete", castFut, newCall(ident "move", ident "result"))
             )
           )
         )
@@ -345,8 +348,12 @@ proc asyncSingleProc(prc, params: NimNode): NimNode {.compileTime.} =
   elif prc.kind in {nnkProcDef, nnkLambda, nnkMethodDef, nnkDo} and
       not isEmpty(prc.body):
     let
-      setResultSym = ident "setResult"
-      procBody = prc.body.processBody(setResultSym)
+      (setResultSym, assignResultSym) =
+        when NimMajor >= 2:
+          (genSym(nskParam, "setResult"), genSym(nskParam, "assignResult"))
+        else:
+          (ident("assignResult"), ident("setResult"))
+      (procBody, assignUsed) = prc.body.processBody(assignResultSym)
       resultIdent = ident "result"
       fakeResult = quote do:
         template result: auto {.used.} =
@@ -400,29 +407,51 @@ proc asyncSingleProc(prc, params: NimNode): NimNode {.compileTime.} =
         if baseTypeIsVoid: # shortcut for non-generic void
           newEmptyNode()
         else:
+          let codeSym = genSym(nskParam, "code")
           nnkTemplateDef.newTree(
             setResultSym,
-            newEmptyNode(), newEmptyNode(),
+            newEmptyNode(),
+            newEmptyNode(),
             nnkFormalParams.newTree(
               newEmptyNode(),
-              nnkIdentDefs.newTree(
-                ident"code",
-                ident"untyped",
-                newEmptyNode(),
-              )
+              nnkIdentDefs.newTree(codeSym, ident"untyped", newEmptyNode()),
             ),
-            nnkPragma.newTree(ident"used"),
+            newEmptyNode(),
             newEmptyNode(),
             nnkWhenStmt.newTree(
               nnkElifBranch.newTree(
-                nnkInfix.newTree(
-                  ident"is", nnkTypeOfExpr.newTree(ident"code"), ident"void"),
-                ident"code"
+                nnkInfix.newTree(ident"is", nnkTypeOfExpr.newTree(codeSym), ident"void"),
+                codeSym,
               ),
-              nnkElse.newTree(
-                newAssignment(resultIdent, ident"code")
-              )
-            )
+              nnkElse.newTree(newAssignment(resultIdent, codeSym)),
+            ),
+          )
+
+      # ```nim
+      # template `assignResultSym`(code: untyped) {.used.} =
+      #   `resultIdent` = code
+      # ```
+      #
+      # a simplified version of `setResult` when the code is known to be a non-void
+      # expression and thus doesn't need the extra `when` layer - we still use
+      # a template so that the right `result` variable gets used inside `code`
+      # in case of shadowing.
+      assignResultDecl =
+        if not assignUsed: # shortcut for non-generic void
+          newEmptyNode()
+        else:
+          let codeSym = genSym(nskParam, "code")
+          nnkTemplateDef.newTree(
+            assignResultSym,
+            newEmptyNode(),
+            newEmptyNode(),
+            nnkFormalParams.newTree(
+              newEmptyNode(),
+              nnkIdentDefs.newTree(codeSym, ident"untyped", newEmptyNode()),
+            ),
+            nnkPragma.newTree(ident"used"),
+            newEmptyNode(),
+            newAssignment(resultIdent, codeSym),
           )
 
       internalFutureSym = ident "chronosInternalRetFuture"
@@ -430,14 +459,14 @@ proc asyncSingleProc(prc, params: NimNode): NimNode {.compileTime.} =
       # Wrapping in try/finally ensures that early returns are handled properly
       # and that `defer` is processed in the right scope
       completeDecl = wrapInTryFinally(
-        castFutureSym, baseType,
+        internalFutureSym, castFutureSym, baseType,
         if baseTypeIsVoid: procBody # shortcut for non-generic `void`
         else: newCall(setResultSym, procBody),
         raises,
         handleException
       )
 
-      closureBody = newStmtList(resultDecl, setResultDecl, completeDecl)
+      closureBody = newStmtList(resultDecl, setResultDecl, assignResultDecl, completeDecl)
 
       internalFutureParameter = nnkIdentDefs.newTree(
         internalFutureSym, newIdentNode("FutureBase"), newEmptyNode())

--- a/chronos/internal/asyncmacro.nim
+++ b/chronos/internal/asyncmacro.nim
@@ -350,7 +350,7 @@ proc asyncSingleProc(prc, params: NimNode): NimNode {.compileTime.} =
     let
       (setResultSym, assignResultSym) =
         when NimMajor >= 2:
-          (genSym(nskParam, "setResult"), genSym(nskParam, "assignResult"))
+          (genSym(nskTemplate, "setResult"), genSym(nskTemplate, "assignResult"))
         else:
           (ident("assignResult"), ident("setResult"))
       (procBody, assignUsed) = prc.body.processBody(assignResultSym)

--- a/tests/testmacro.nim
+++ b/tests/testmacro.nim
@@ -624,3 +624,44 @@ suite "Exceptions tracking":
 
     check:
       waitFor(testit()).error() == "failed"
+
+  test "await with defer":
+    when (NimMajor, NimMinor, NimPatch) >= (2, 2, 6):
+      # https://github.com/status-im/nim-chronos/issues/576
+      var aaa: int
+      var bbb: int
+      var ccc: int
+
+      proc doStuff() {.async.} =
+        defer:
+          for i in 0 ..< 3:
+            try:
+              await sleepAsync(10.milliseconds)
+            except:
+              discard
+
+            bbb += 1
+
+        for i in 0 ..< 3:
+          try:
+            await sleepAsync(10.milliseconds)
+          except:
+            discard
+          aaa += 1
+
+        raise newException(CatchableError, "")
+
+      proc main() {.async.} =
+        try:
+          await doStuff()
+        except:
+          ccc += 1
+
+      waitFor main()
+
+      check:
+        aaa == 3
+        bbb == 3
+        ccc == 1
+    else:
+      skip()


### PR DESCRIPTION
* `return` is always followed by an expression, so we don't need `when typeof(..) is void`
* `fail` checks raises signatures, but this is not needed for the internally generated code that by construction always uses the right type
* `complete` is generic, so move some non-generic code out of it to make
each instantiation smaller
* document defer fix with test