### PR TITLE
async: set line info for setResult

### DIFF
--- a/chronos/internal/asyncmacro.nim
+++ b/chronos/internal/asyncmacro.nim
@@ -477,6 +477,8 @@ proc asyncSingleProc(prc, params: NimNode): NimNode {.compileTime.} =
         [newIdentNode("FutureBase"), internalFutureParameter],
         closureBody, nnkIteratorDef)
 
+    setResultSym.copyLineInfo(procBody)
+    assignResultSym.copyLineInfo(procBody)
     iteratorNameSym.copyLineInfo(prc)
 
     closureIterator.pragma = newNimNode(nnkPragma, lineInfoFrom=prc.body)


### PR DESCRIPTION
Avoids a common lineinfo pointing to `asyncmacro` when raising