### PR TITLE
Avoid race when reading and writing concurrently on TLS stream

### DIFF
--- a/chronos/streams/tlsstream.nim
+++ b/chronos/streams/tlsstream.nim
@@ -197,7 +197,7 @@ proc runUntil(rws: TLSAsyncStream, target: cuint): Future[void] {.
   let engine = rws.engine()
   while true:
     func remainingState(
-        rws: TLSAsyncStream, target: cuint
+        rws: TLSAsyncStream, engine: ptr SslEngineContext, target: cuint
     ): Opt[cuint] {.raises: [AsyncStreamError].} =
       let err = sslEngineLastError(engine[])
       if err != 0:
@@ -214,13 +214,13 @@ proc runUntil(rws: TLSAsyncStream, target: cuint): Future[void] {.
 
       Opt.some state
 
-    if rws.remainingState(target).isNone:
+    if rws.remainingState(engine, target).isNone:
       break
 
     # Prevent concurrent reads and writes from interfering with each other
     await rws.lock.acquire()
     try:
-      let state = rws.remainingState(target).valueOr:
+      let state = rws.remainingState(engine, target).valueOr:
         break
 
       # If the engine is ready for reading, start a read operation - although

--- a/chronos/streams/tlsstream.nim
+++ b/chronos/streams/tlsstream.nim
@@ -157,9 +157,6 @@ template newTLSStreamProtocolImpl[T](message: T): ref TLSStreamProtocolError =
   err.errCode = code
   err
 
-template newTLSUnexpectedProtocolError(): ref TLSStreamProtocolError =
-  newException(TLSStreamProtocolError, "Unexpected internal error")
-
 proc newTLSStreamProtocolError[T](message: T): ref TLSStreamProtocolError =
   newTLSStreamProtocolImpl(message)
 
@@ -199,22 +196,34 @@ proc runUntil(rws: TLSAsyncStream, target: cuint): Future[void] {.
      async: (raises: [CancelledError, AsyncStreamError]).} =
   let engine = rws.engine()
   while true:
-    let err = sslEngineLastError(engine[])
-    if err != 0:
-      raise newTLSStreamProtocolError(err)
+    func remainingState(
+        rws: TLSAsyncStream, target: cuint
+    ): Opt[cuint] {.raises: [AsyncStreamError].} =
+      let err = sslEngineLastError(engine[])
+      if err != 0:
+        raise newTLSStreamProtocolError(err)
 
+      let state = sslEngineCurrentState(engine[])
+      if (state and SSL_CLOSED) == SSL_CLOSED:
+        return Opt.none cuint
+
+      if ((state and target) == target):
+        if (state and SSL_SENDAPP) == SSL_SENDAPP:
+          rws.handshaked = true
+        return Opt.none cuint
+
+      Opt.some state
+
+    if rws.remainingState(target).isNone:
+      break
     let state = sslEngineCurrentState(engine[])
-    if (state and SSL_CLOSED) == SSL_CLOSED:
-      break
-
-    if ((state and target) == target):
-      if (state and SSL_SENDAPP) == SSL_SENDAPP:
-        rws.handshaked = true
-      break
 
     # Prevent concurrent reads and writes from interfering with each other
     await rws.lock.acquire()
     try:
+      let state = rws.remainingState(target).valueOr:
+        break
+
       # If the engine is ready for reading, start a read operation - although
       # we start reading here, it's important to exhaust SSL_SENDREC before
       # blocking on reads or the protocol will deadlock during handshakes

--- a/chronos/streams/tlsstream.nim
+++ b/chronos/streams/tlsstream.nim
@@ -216,7 +216,6 @@ proc runUntil(rws: TLSAsyncStream, target: cuint): Future[void] {.
 
     if rws.remainingState(target).isNone:
       break
-    let state = sslEngineCurrentState(engine[])
 
     # Prevent concurrent reads and writes from interfering with each other
     await rws.lock.acquire()

--- a/tests/testasyncstream.nim
+++ b/tests/testasyncstream.nim
@@ -953,8 +953,8 @@ suite "AsyncStream/TLSStream":
 
   asyncTest "Concurrent read and write":
     const
-      ChunkSize = 256
-      TotalSize = 2048
+      ChunkSize = 16
+      TotalSize = 128
 
     proc readWrite(s: TLSAsyncStream) {.async: (raw: true).} =
       proc doWrite() {.async.} =

--- a/tests/testasyncstream.nim
+++ b/tests/testasyncstream.nim
@@ -951,6 +951,68 @@ suite "AsyncStream/TLSStream":
     await server.join()
     check string.fromBytes(res) == (testMessage & "\r\n")
 
+  asyncTest "Concurrent read and write":
+    const
+      ChunkSize = 256
+      TotalSize = 2048
+
+    proc readWrite(s: TLSAsyncStream) {.async: (raw: true).} =
+      proc doWrite() {.async.} =
+        let chunk = newSeq[byte](ChunkSize)
+        var length = 0
+        while length < TotalSize:
+          await s.writer.write(chunk)
+          await stepsAsync(1)
+          length += chunk.len
+
+      proc doRead() {.async.} =
+        var length = 0
+        while length < TotalSize:
+          let chunk = await s.reader.read(ChunkSize)
+          if chunk.len == 0:
+            break
+          await stepsAsync(1)
+          length += chunk.len
+
+      allFutures(doWrite(), doRead())
+
+    let key = TLSPrivateKey.init(SelfSignedRsaKey)
+    let cert = TLSCertificate.init(SelfSignedRsaCert)
+    proc serveClient(server: StreamServer,
+                     transp: StreamTransport) {.async: (raises: []).} =
+      try:
+        var reader = newAsyncStreamReader(transp)
+        var writer = newAsyncStreamWriter(transp)
+        var sstream = newTLSServerAsyncStream(reader, writer, key, cert)
+        await handshake(sstream)
+        await readWrite(sstream)
+        await sstream.writer.closeWait()
+        await sstream.reader.closeWait()
+        await reader.closeWait()
+        await writer.closeWait()
+        await transp.closeWait()
+        server.stop()
+        server.close()
+      except CatchableError as exc:
+        raiseAssert exc.msg
+
+    var server = createStreamServer(initTAddress("127.0.0.1:0"),
+                                    serveClient, {ReuseAddr})
+    server.start()
+    var conn = await connect(server.localAddress())
+    var creader = newAsyncStreamReader(conn)
+    var cwriter = newAsyncStreamWriter(conn)
+    let flags = {NoVerifyHost, NoVerifyServerName}
+    var cstream = newTLSClientAsyncStream(creader, cwriter, "", flags = flags)
+    await handshake(cstream)
+    await readWrite(cstream)
+    await cstream.writer.closeWait()
+    await cstream.reader.closeWait()
+    await creader.closeWait()
+    await cwriter.closeWait()
+    await conn.closeWait()
+    await server.join()
+
   const TestVectors = [
     ("test", 56, "X509BadServerName"),
     ("chronos-server-test.com", 62, "X509NotTrusted")

--- a/tests/testasyncstream.nim
+++ b/tests/testasyncstream.nim
@@ -964,6 +964,7 @@ suite "AsyncStream/TLSStream":
           await s.writer.write(chunk)
           await stepsAsync(1)
           length += chunk.len
+        await sleepAsync(1)
 
       proc doRead() {.async.} =
         var length = 0


### PR DESCRIPTION
Engine state can change while awaiting lock acquisition from #643, and trigger `sslEngineSendrecBuf` even though different task already read: `length != 0` doesn't necessary hold in that case -> `AssertionDefect`.