### PR TITLE
allow `do {.async.}` (fixes #552)

### DIFF
--- a/chronos/internal/asyncmacro.nim
+++ b/chronos/internal/asyncmacro.nim
@@ -314,7 +314,7 @@ proc asyncSingleProc(prc, params: NimNode): NimNode {.compileTime.} =
 
   prc.params2[0] = internalReturnType
 
-  if prc.kind notin {nnkProcTy, nnkLambda}:
+  if prc.kind notin {nnkProcTy, nnkLambda, nnkDo}:
     prc.addPragma(newColonExpr(ident "stackTrace", ident "off"))
 
   # The proc itself doesn't raise

--- a/tests/testmacro.nim
+++ b/tests/testmacro.nim
@@ -665,3 +665,16 @@ suite "Exceptions tracking":
         ccc == 1
     else:
       skip()
+
+  test "async do":
+    var called = false
+    proc callProc[T](f: proc (): T {.raises: [], gcsafe.}): T =
+      f()
+
+    proc foo() {.async.} =
+      await callProc do {.async.}:
+        called = true
+    waitFor foo()
+    check:
+      called
+


### PR DESCRIPTION
do block cannot be stacktrace-annotated