### PR TITLE
Always report Event.Error to both read/write callbacks

### DIFF
--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -1022,11 +1022,11 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       let events = loop.keys[i].events
 
       withData(loop.selector, cint(fd), adata) do:
-        if (Event.Read in events) or (events == {Event.Error}):
+        if (Event.Read in events) or (Event.Error in events):
           if not isNil(adata.reader.function):
             loop.callbacks.addLast(adata.reader)
 
-        if (Event.Write in events) or (events == {Event.Error}):
+        if (Event.Write in events) or (Event.Error in events):
           if not isNil(adata.writer.function):
             loop.callbacks.addLast(adata.writer)
 

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -1022,11 +1022,11 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       let events = loop.keys[i].events
 
       withData(loop.selector, cint(fd), adata) do:
-        if (Event.Read in events) or (Event.Error in events):
+        if {Event.Read, Event.Error} * events != {}:
           if not isNil(adata.reader.function):
             loop.callbacks.addLast(adata.reader)
 
-        if (Event.Write in events) or (Event.Error in events):
+        if {Event.Write, Event.Error} * events != {}:
           if not isNil(adata.writer.function):
             loop.callbacks.addLast(adata.writer)
 

--- a/chronos/ioselects/ioselectors_poll.nim
+++ b/chronos/ioselects/ioselectors_poll.nim
@@ -207,7 +207,7 @@ proc prepareKey[T](s: Selector[T], event: var TPollfd): Opt[ReadyKey] =
     rkey.events.incl(Event.Write)
 
   if (revents and POLLERR) != 0 or (revents and POLLHUP) != 0 or
-     (event.events and EPOLLRDHUP) != 0 or (revents and POLLNVAL) != 0:
+     (revents and EPOLLRDHUP) != 0 or (revents and POLLNVAL) != 0:
     rkey.events.incl(Event.Error)
 
   ok(rkey)

--- a/chronos/ioselects/ioselectors_poll.nim
+++ b/chronos/ioselects/ioselectors_poll.nim
@@ -207,7 +207,7 @@ proc prepareKey[T](s: Selector[T], event: var TPollfd): Opt[ReadyKey] =
     rkey.events.incl(Event.Write)
 
   if (revents and POLLERR) != 0 or (revents and POLLHUP) != 0 or
-     (revents and POLLNVAL) != 0:
+     (event.events and EPOLLRDHUP) != 0 or (revents and POLLNVAL) != 0:
     rkey.events.incl(Event.Error)
 
   ok(rkey)

--- a/chronos/ioselects/ioselectors_poll.nim
+++ b/chronos/ioselects/ioselectors_poll.nim
@@ -207,7 +207,7 @@ proc prepareKey[T](s: Selector[T], event: var TPollfd): Opt[ReadyKey] =
     rkey.events.incl(Event.Write)
 
   if (revents and POLLERR) != 0 or (revents and POLLHUP) != 0 or
-     (revents and EPOLLRDHUP) != 0 or (revents and POLLNVAL) != 0:
+     (revents and POLLRDHUP) != 0 or (revents and POLLNVAL) != 0:
     rkey.events.incl(Event.Error)
 
   ok(rkey)

--- a/chronos/ioselects/ioselectors_poll.nim
+++ b/chronos/ioselects/ioselectors_poll.nim
@@ -91,8 +91,15 @@ proc close2*(event: SelectEvent): SelectResult[void] =
   else:
     ok()
 
+const POLLRDHUP =
+  when compiles(EPOLLRDHUP):
+    static: doAssert EPOLLRDHUP <= cshort.high
+    cshort(EPOLLRDHUP)
+  else:
+    cshort(0)
+
 template toPollEvents(events: set[Event]): cshort =
-  var res = cshort(0)
+  var res = cshort(POLLRDHUP)
   if Event.Read in events: res = res or POLLIN
   if Event.Write in events: res = res or POLLOUT
   res

--- a/tests/testbugs.nim
+++ b/tests/testbugs.nim
@@ -188,12 +188,6 @@ suite "Asynchronous issues test suite":
       while handleEintr(osdefs.write(sockets[0], baseAddr buf, buf.len)) > 0:
         discard
 
-      when chronosEventEngine == "poll":
-        # Linux uses POLLRDHUP not POLLHUP for half-closed socket,
-        # but poll engine only processes POLLHUP. Completely close
-        # to force {Event.Error} (EOF) to be set.
-        discard osdefs.close(sockets[1])
-
       func setFlag(udata: pointer) =
         let flag = cast[ptr bool](udata)
         doAssert not(flag[])

--- a/tests/testbugs.nim
+++ b/tests/testbugs.nim
@@ -10,7 +10,7 @@ import ../chronos
 
 when defined(posix):
   import stew/ptrops
-  import ../chronos/[osdefs, osutils]
+  import ../chronos/[config, osdefs, osutils]
 
 {.used.}
 
@@ -188,6 +188,12 @@ suite "Asynchronous issues test suite":
       while handleEintr(osdefs.write(sockets[0], baseAddr buf, buf.len)) > 0:
         discard
 
+      when chronosEventEngine == "poll":
+        # Linux uses POLLRDHUP not POLLHUP for half-closed socket,
+        # but poll engine only processes POLLHUP. Completely close
+        # to force {Event.Error} (EOF) to be set.
+        discard osdefs.close(sockets[1])
+
       func setFlag(udata: pointer) =
         let flag = cast[ptr bool](udata)
         doAssert not(flag[])
@@ -204,4 +210,5 @@ suite "Asynchronous issues test suite":
         unregister2(AsyncFD(sockets[0])).isOk()
 
       discard osdefs.close(sockets[0])
-      discard osdefs.close(sockets[1])
+      when chronosEventEngine != "poll":
+        discard osdefs.close(sockets[1])

--- a/tests/testbugs.nim
+++ b/tests/testbugs.nim
@@ -8,6 +8,10 @@
 import unittest2
 import ../chronos
 
+when defined(posix):
+  import stew/ptrops
+  import ../chronos/[osdefs, osutils]
+
 {.used.}
 
 suite "Asynchronous issues test suite":
@@ -165,3 +169,39 @@ suite "Asynchronous issues test suite":
 
   test "`or` deadlock [#516] test":
     check waitFor(testOrDeadlock()) == true
+
+  when defined(posix):
+    test "{Event.Read, Event.Error} handling [poll()] test":
+      var sockets: array[2, cint]
+      check:
+        socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0
+        setDescriptorBlocking(sockets[0], false).isOk()
+
+      # Ensure {Event.Read} and {Event.Error} (EOF) are set
+      var b = 42.byte
+      check:
+        handleEintr(osdefs.write(sockets[1], addr b, 1)) == 1
+        osdefs.shutdown(SocketHandle(sockets[1]), SHUT_WR) == 0
+
+      # Avoid {Event.Write} being set, by filling up the send buffer
+      var buf: array[65536, byte]
+      while handleEintr(osdefs.write(sockets[0], baseAddr buf, buf.len)) > 0:
+        discard
+
+      func setFlag(udata: pointer) =
+        let flag = cast[ptr bool](udata)
+        doAssert not(flag[])
+        flag[] = true
+
+      var readerFlag, writerFlag: bool
+      check:
+        register2(AsyncFD(sockets[0])).isOk()
+        addReader2(AsyncFD(sockets[0]), setFlag, addr readerFlag).isOk()
+        addWriter2(AsyncFD(sockets[0]), setFlag, addr writerFlag).isOk()
+      poll()
+      check:
+        readerFlag and writerFlag
+        unregister2(AsyncFD(sockets[0])).isOk()
+
+      discard osdefs.close(sockets[0])
+      discard osdefs.close(sockets[1])

--- a/tests/testbugs.nim
+++ b/tests/testbugs.nim
@@ -174,7 +174,7 @@ suite "Asynchronous issues test suite":
     test "{Event.Read, Event.Error} handling [poll()] test":
       var sockets: array[2, cint]
       check:
-        socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0
+        socketpair(osdefs.AF_UNIX, osdefs.SOCK_STREAM, 0, sockets) == 0
         setDescriptorBlocking(sockets[0], false).isOk()
 
       # Ensure {Event.Read} and {Event.Error} (EOF) are set


### PR DESCRIPTION
When `Event.Error` is paired with additional flags, it does not always wake up the reader / writer callbacks. For example, `{Read, Error}` does not wake up the writer callack; however, standalone `{Error}` does.

Not issuing both callbacks can leak futures, e.g., the `writeStreamLoop` would never complete or fail as it is never resumed.