### PR TITLE
work around `error` return warning

### DIFF
--- a/chronos/internal/asyncmacro.nim
+++ b/chronos/internal/asyncmacro.nim
@@ -13,6 +13,13 @@ import
   ../[futures, config],
   ./raisesfutures
 
+template errorReturnWorkaround(body) =
+  when NimMajor < 2:
+    body
+    raiseAssert "never hit"
+  else:
+    body
+
 proc processBody(node, setResultSym: NimNode): (NimNode, bool) {.compileTime.} =
   case node.kind
   of nnkReturnStmt:
@@ -283,9 +290,10 @@ proc asyncSingleProc(prc, params: NimNode): NimNode {.compileTime.} =
     elif not (
         returnType.kind == nnkBracketExpr and
         (eqIdent(returnType[0], "Future") or eqIdent(returnType[0], "InternalRaisesFuture"))):
-      error(
-        "Expected return type of 'Future' got '" & repr(returnType) & "'", prc)
-      return
+      errorReturnWorkaround:
+        error(
+          "Expected return type of 'Future' got '" & repr(returnType) & "'", prc)
+
     else:
       returnType[1]
 

--- a/chronos/internal/raisesfutures.nim
+++ b/chronos/internal/raisesfutures.nim
@@ -4,6 +4,14 @@ import
 
 {.push raises: [].}
 
+template errorReturnWorkaround(body) =
+  when NimMajor < 2:
+    body
+    raiseAssert "never hit"
+  else:
+    body
+
+
 type
   InternalRaisesFuture*[T, E] = ref object of Future[T]
     ## Future with a tuple of possible exception types
@@ -78,8 +86,8 @@ macro Raising*[T](F: typedesc[Future[T]], E: typed): untyped =
             error("Expected typedesc, got " & repr(x), x)
         E.mapIt(it)
       else:
-        error("Expected typedesc, got " & repr(E), E)
-        @[]
+        errorReturnWorkaround:
+          error("Expected typedesc, got " & repr(E), E)
 
   let raises = if e.len == 0:
     makeNoRaises()
@@ -194,9 +202,9 @@ macro checkRaises*[T: CatchableError](
 
 
   if isNoRaises(raises):
-    error(
-      "`fail`: `" & repr(toMatch) & "` incompatible with `raises: []`", future)
-    return
+    errorReturnWorkaround:
+      error(
+        "`fail`: `" & repr(toMatch) & "` incompatible with `raises: []`", future)
 
   var
     typeChecker = ident"false"


### PR DESCRIPTION
`error` lacks `noreturn` earlier