### PR TITLE
Add helper for parsing Authorization headers

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -11,7 +11,7 @@ requires "nim >= 1.6.16",
          "results",
          "stew >= 0.5.0",
          "bearssl >= 0.2.8",
-         "httputils",
+         "httputils >= 0.4.2",
          "unittest2"
 
 import os, strutils

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -11,7 +11,7 @@ requires "nim >= 1.6.16",
          "results",
          "stew >= 0.5.0",
          "bearssl >= 0.2.8",
-         "httputils >= 0.4.2",
+         "httputils >= 0.4.3",
          "unittest2"
 
 import os, strutils

--- a/chronos/apps/http/httpcommon.nim
+++ b/chronos/apps/http/httpcommon.nim
@@ -90,6 +90,10 @@ type
     key: string
     value: string
 
+  AuthorizationData* = object
+    scheme*: string
+    credentials*: string
+
   TransferEncodingFlags* {.pure.} = enum
     Identity, Chunked, Compress, Deflate, Gzip
 
@@ -328,6 +332,39 @@ func getContentType*(ch: openArray[string]): HttpResult[ContentTypeData] =
     if res.isErr():
       return err($res.error())
     ok(res.get())
+
+func getAuthorization*(ch: openArray[string]): HttpResult[AuthorizationData] =
+  ## Check and prepare value of ``Authorization`` header.
+  ##
+  ## The authentication scheme is normalized to lower case, the credentials
+  ## are returned verbatim.
+  # https://www.rfc-editor.org/info/rfc9110/#section-11.4
+  # credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]
+  # auth-scheme = token
+  # https://www.rfc-editor.org/info/rfc9110/#section-5.6.2
+  # token = 1*tchar
+  const TCHAR = TOKEND + NUM + ALPHA
+  if len(ch) == 0:
+    err("No Authorization values found")
+  elif len(ch) > 1:
+    err("Multiple Authorization values found")
+  else:
+    # https://www.rfc-editor.org/info/rfc9110/#section-5.5
+    # A field value does not include leading or trailing whitespace.
+    let value = strip(ch[0], chars = SPACE)
+    var index = 0
+    for c in value:
+      if c == ' ':
+        break
+      if c notin TCHAR:
+        return err("Invalid Authorization value")
+      inc(index)
+    if index == 0:
+      return err("Invalid Authorization value")
+    let scheme = value[0 ..< index].toLowerAscii()
+    while index < len(value) and value[index] == ' ':
+      inc(index)
+    ok(AuthorizationData(scheme: scheme, credentials: value[index .. ^1]))
 
 proc bytesToString*(src: openArray[byte], dst: var openArray[char]) =
   ## Convert array of bytes to array of characters.

--- a/chronos/apps/http/httpcommon.nim
+++ b/chronos/apps/http/httpcommon.nim
@@ -343,7 +343,6 @@ func getAuthorization*(ch: openArray[string]): HttpResult[AuthorizationData] =
   # auth-scheme = token
   # https://www.rfc-editor.org/info/rfc9110/#section-5.6.2
   # token = 1*tchar
-  const TCHAR = TOKEND + NUM + ALPHA
   if len(ch) == 0:
     err("No Authorization values found")
   elif len(ch) > 1:

--- a/chronos/apps/http/httpcommon.nim
+++ b/chronos/apps/http/httpcommon.nim
@@ -90,10 +90,6 @@ type
     key: string
     value: string
 
-  AuthorizationData* = object
-    scheme*: string
-    credentials*: string
-
   TransferEncodingFlags* {.pure.} = enum
     Identity, Chunked, Compress, Deflate, Gzip
 
@@ -335,35 +331,15 @@ func getContentType*(ch: openArray[string]): HttpResult[ContentTypeData] =
 
 func getAuthorization*(ch: openArray[string]): HttpResult[AuthorizationData] =
   ## Check and prepare value of ``Authorization`` header.
-  ##
-  ## The authentication scheme is normalized to lower case, the credentials
-  ## are returned verbatim.
-  # https://www.rfc-editor.org/info/rfc9110/#section-11.4
-  # credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]
-  # auth-scheme = token
-  # https://www.rfc-editor.org/info/rfc9110/#section-5.6.2
-  # token = 1*tchar
   if len(ch) == 0:
     err("No Authorization values found")
   elif len(ch) > 1:
     err("Multiple Authorization values found")
   else:
-    # https://www.rfc-editor.org/info/rfc9110/#section-5.5
-    # A field value does not include leading or trailing whitespace.
-    let value = strip(ch[0], chars = SPACE)
-    var index = 0
-    for c in value:
-      if c == ' ':
-        break
-      if c notin TCHAR:
-        return err("Invalid Authorization value")
-      inc(index)
-    if index == 0:
-      return err("Invalid Authorization value")
-    let scheme = value[0 ..< index].toLowerAscii()
-    while index < len(value) and value[index] == ' ':
-      inc(index)
-    ok(AuthorizationData(scheme: scheme, credentials: value[index .. ^1]))
+    let res = getAuthorization(ch[0])
+    if res.isErr():
+      return err($res.error())
+    ok(res.get())
 
 proc bytesToString*(src: openArray[byte], dst: var openArray[char]) =
   ## Convert array of bytes to array of characters.

--- a/tests/testhttpserver.nim
+++ b/tests/testhttpserver.nim
@@ -956,44 +956,13 @@ suite "HTTP server testing suite":
       getContentEncoding(["", ""]).tryGet() == { ContentEncodingFlags.Identity }
 
   test "getAuthorization() test":
-    const
-      SuccessVectors = [
-        ("Bearer aGVsbG8=", "bearer", "aGVsbG8="),
-        ("bearer aGVsbG8=", "bearer", "aGVsbG8="),
-        ("BEARER aGVsbG8=", "bearer", "aGVsbG8="),
-        ("BeArEr aGVsbG8=", "bearer", "aGVsbG8="),
-        ("Bearer    aGVsbG8=", "bearer", "aGVsbG8="),
-        ("Bearer aGVsbG8= ", "bearer", "aGVsbG8="),
-        ("Bearer aGVsbG8=\t", "bearer", "aGVsbG8="),
-        (" Bearer aGVsbG8=", "bearer", "aGVsbG8="),
-        ("\tBearer aGVsbG8=", "bearer", "aGVsbG8="),
-        ("Basic dXNlcjpwYXNz", "basic", "dXNlcjpwYXNz"),
-        ("Digest username=\"user\", realm=\"realm\"", "digest",
-         "username=\"user\", realm=\"realm\""),
-        ("Bearer", "bearer", ""),
-        ("Bearer ", "bearer", "")
-      ]
-      FailureVectors = [
-        "",
-        " ",
-        "Bear\ter aGVsbG8=",
-        "Bearer\taGVsbG8=",
-        "(Bearer) aGVsbG8="
-      ]
-
-    for vector in SuccessVectors:
-      let res = getAuthorization([vector[0]])
-      check:
-        res.isOk()
-        res.get() == AuthorizationData(scheme: vector[1],
-                                       credentials: vector[2])
-
-    for vector in FailureVectors:
-      check getAuthorization([vector]).isErr()
-
     check:
+      getAuthorization(["Bearer aGVsbG8="]).tryGet() ==
+        AuthorizationData(status: HttpStatus.Success,
+                          scheme: "bearer", credentials: "aGVsbG8=")
       getAuthorization([]).isErr()
       getAuthorization(["Bearer aaa", "Bearer bbb"]).isErr()
+      getAuthorization(["(Bearer) aGVsbG8="]).isErr()
 
   test "queryParams() test":
     const Vectors = [

--- a/tests/testhttpserver.nim
+++ b/tests/testhttpserver.nim
@@ -965,6 +965,8 @@ suite "HTTP server testing suite":
         ("Bearer    aGVsbG8=", "bearer", "aGVsbG8="),
         ("Bearer aGVsbG8= ", "bearer", "aGVsbG8="),
         ("Bearer aGVsbG8=\t", "bearer", "aGVsbG8="),
+        (" Bearer aGVsbG8=", "bearer", "aGVsbG8="),
+        ("\tBearer aGVsbG8=", "bearer", "aGVsbG8="),
         ("Basic dXNlcjpwYXNz", "basic", "dXNlcjpwYXNz"),
         ("Digest username=\"user\", realm=\"realm\"", "digest",
          "username=\"user\", realm=\"realm\""),
@@ -973,8 +975,9 @@ suite "HTTP server testing suite":
       ]
       FailureVectors = [
         "",
-        " Bearer aGVsbG8=",
+        " ",
         "Bear\ter aGVsbG8=",
+        "Bearer\taGVsbG8=",
         "(Bearer) aGVsbG8="
       ]
 

--- a/tests/testhttpserver.nim
+++ b/tests/testhttpserver.nim
@@ -955,6 +955,43 @@ suite "HTTP server testing suite":
       getContentEncoding([]).tryGet() == { ContentEncodingFlags.Identity }
       getContentEncoding(["", ""]).tryGet() == { ContentEncodingFlags.Identity }
 
+  test "getAuthorization() test":
+    const
+      SuccessVectors = [
+        ("Bearer aGVsbG8=", "bearer", "aGVsbG8="),
+        ("bearer aGVsbG8=", "bearer", "aGVsbG8="),
+        ("BEARER aGVsbG8=", "bearer", "aGVsbG8="),
+        ("BeArEr aGVsbG8=", "bearer", "aGVsbG8="),
+        ("Bearer    aGVsbG8=", "bearer", "aGVsbG8="),
+        ("Bearer aGVsbG8= ", "bearer", "aGVsbG8="),
+        ("Bearer aGVsbG8=\t", "bearer", "aGVsbG8="),
+        ("Basic dXNlcjpwYXNz", "basic", "dXNlcjpwYXNz"),
+        ("Digest username=\"user\", realm=\"realm\"", "digest",
+         "username=\"user\", realm=\"realm\""),
+        ("Bearer", "bearer", ""),
+        ("Bearer ", "bearer", "")
+      ]
+      FailureVectors = [
+        "",
+        " Bearer aGVsbG8=",
+        "Bear\ter aGVsbG8=",
+        "(Bearer) aGVsbG8="
+      ]
+
+    for vector in SuccessVectors:
+      let res = getAuthorization([vector[0]])
+      check:
+        res.isOk()
+        res.get() == AuthorizationData(scheme: vector[1],
+                                       credentials: vector[2])
+
+    for vector in FailureVectors:
+      check getAuthorization([vector]).isErr()
+
+    check:
+      getAuthorization([]).isErr()
+      getAuthorization(["Bearer aaa", "Bearer bbb"]).isErr()
+
   test "queryParams() test":
     const Vectors = [
       ("id=1&id=2&id=3&id=4", {}, "id:1,id:2,id:3,id:4"),


### PR DESCRIPTION
Clients such as nimbus-eth2 rest_key_management_api currently hand-parse the HTTP Authorization header, and do so incompletely (scheme should be case-insensitive according to HTTP specs). Providing a helper enables migration to correct usage.