### PR TITLE
Fix getAddress deprecated warning

### DIFF
--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -438,13 +438,13 @@ proc redirect*(srcuri, dsturi: Uri): Uri =
     combine(srcuri, tmpuri)
 
 proc redirect*(session: HttpSessionRef,
-               srcaddr: HttpAddress, uri: Uri): HttpResult[HttpAddress] =
+               srcaddr: HttpAddress, uri: Uri): HttpAddressResult =
   ## Transform original address ``srcaddr`` using redirected url ``uri`` and
   ## session ``session`` parameters.
   let srcuri = srcaddr.getUri()
   var newuri = srcuri.redirect(uri)
   if newuri.hostname != srcuri.hostname:
-    session.getAddress(newuri)
+    session.getHttpAddress(newuri)
   else:
     let scheme =
       case newuri.scheme
@@ -1049,7 +1049,7 @@ proc new*(t: typedesc[HttpClientRequestRef], session: HttpSessionRef,
           maxResponseHeadersSize: int = HttpMaxHeadersSize,
           headers: openArray[HttpHeaderTuple] = [],
           body: openArray[byte] = []): HttpResult[HttpClientRequestRef] =
-  let address = ? session.getAddress(parseUri(url))
+  let address = ? session.getHttpAddress(parseUri(url))
   ok HttpClientRequestRef.new(
     session, address, meth, version, flags, maxResponseHeadersSize, headers,
     body)
@@ -1081,7 +1081,7 @@ when chronosUseSink:
             headers: openArray[HttpHeaderTuple] = [],
             body: sink seq[byte]):
               HttpResult[HttpClientRequestRef] =
-    let ha = ? session.getAddress(parseUri(url))
+    let ha = ? session.getHttpAddress(parseUri(url))
     ok HttpClientRequestRef.new(
       session, ha, meth, version, flags, maxResponseHeadersSize, headers,
       move(body))
@@ -1327,7 +1327,7 @@ proc send*(request: HttpClientRequestRef): Future[HttpClientResponseRef] {.
 
   await request.finish()
 
-proc getNewLocation*(resp: HttpClientResponseRef): HttpResult[HttpAddress] =
+proc getNewLocation*(resp: HttpClientResponseRef): HttpAddressResult =
   ## Returns new address according to response's `Location` header value.
   if "location" in resp.headers:
     let location = resp.headers.getString("location")
@@ -1594,7 +1594,8 @@ proc redirect*(request: HttpClientRequestRef,
   if redirectCount > request.session.maxRedirections:
     err("Maximum number of redirects exceeded")
   else:
-    let address = ? request.session.redirect(request.address, uri)
+    let address = request.session.redirect(request.address, uri).valueOr:
+      return err($error)
     # Update Host header to redirected URL hostname
     let headers =
       block:

--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -438,13 +438,15 @@ proc redirect*(srcuri, dsturi: Uri): Uri =
     combine(srcuri, tmpuri)
 
 proc redirect*(session: HttpSessionRef,
-               srcaddr: HttpAddress, uri: Uri): HttpAddressResult =
+               srcaddr: HttpAddress, uri: Uri): HttpResult[HttpAddress] =
   ## Transform original address ``srcaddr`` using redirected url ``uri`` and
   ## session ``session`` parameters.
   let srcuri = srcaddr.getUri()
   var newuri = srcuri.redirect(uri)
   if newuri.hostname != srcuri.hostname:
-    session.getHttpAddress(newuri)
+    session.getHttpAddress(newuri).mapErr(
+      func (exc: HttpAddressErrorType): string = $exc
+    )
   else:
     let scheme =
       case newuri.scheme
@@ -453,7 +455,7 @@ proc redirect*(session: HttpSessionRef,
       of "https":
         HttpClientScheme.Secure
       else:
-        return err(HttpAddressErrorType.InvalidUrlScheme)
+        return err("URL scheme not supported")
 
     let port =
       if len(newuri.port) == 0:
@@ -464,10 +466,10 @@ proc redirect*(session: HttpSessionRef,
           443'u16
       else:
         Base10.decode(uint16, newuri.port).valueOr:
-          return err(HttpAddressErrorType.InvalidPortNumber)
+          return err("Invalid URL port number")
 
     if len(newuri.hostname) == 0:
-      return err(HttpAddressErrorType.MissingHostname)
+      return err("URL hostname is missing")
 
     let id = newuri.hostname & ":" & Base10.toString(port)
 
@@ -1327,16 +1329,16 @@ proc send*(request: HttpClientRequestRef): Future[HttpClientResponseRef] {.
 
   await request.finish()
 
-proc getNewLocation*(resp: HttpClientResponseRef): HttpAddressResult =
+proc getNewLocation*(resp: HttpClientResponseRef): HttpResult[HttpAddress] =
   ## Returns new address according to response's `Location` header value.
   if "location" in resp.headers:
     let location = resp.headers.getString("location")
     if len(location) > 0:
       resp.session.redirect(resp.address, parseUri(location))
     else:
-      err(HttpAddressErrorType.EmptyLocationHeader)
+      err("Location header with empty value")
   else:
-    err(HttpAddressErrorType.MissingLocationHeader)
+    err("Location header is missing")
 
 proc getBodyReader*(response: HttpClientResponseRef): HttpBodyReader {.
      raises: [HttpUseClosedError].} =

--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -453,7 +453,7 @@ proc redirect*(session: HttpSessionRef,
       of "https":
         HttpClientScheme.Secure
       else:
-        return err("URL scheme not supported")
+        return err(HttpAddressErrorType.InvalidUrlScheme)
 
     let port =
       if len(newuri.port) == 0:
@@ -464,10 +464,10 @@ proc redirect*(session: HttpSessionRef,
           443'u16
       else:
         Base10.decode(uint16, newuri.port).valueOr:
-          return err("Invalid URL port number")
+          return err(HttpAddressErrorType.InvalidPortNumber)
 
     if len(newuri.hostname) == 0:
-      return err("URL hostname is missing")
+      return err(HttpAddressErrorType.MissingHostname)
 
     let id = newuri.hostname & ":" & Base10.toString(port)
 
@@ -1334,9 +1334,9 @@ proc getNewLocation*(resp: HttpClientResponseRef): HttpResult[HttpAddress] =
     if len(location) > 0:
       resp.session.redirect(resp.address, parseUri(location))
     else:
-      err("Location header with empty value")
+      err(HttpAddressErrorType.EmptyLocationHeader)
   else:
-    err("Location header is missing")
+    err(HttpAddressErrorType.MissingLocationHeader)
 
 proc getBodyReader*(response: HttpClientResponseRef): HttpBodyReader {.
      raises: [HttpUseClosedError].} =

--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -445,7 +445,7 @@ proc redirect*(session: HttpSessionRef,
   var newuri = srcuri.redirect(uri)
   if newuri.hostname != srcuri.hostname:
     session.getHttpAddress(newuri).mapErr(
-      func (exc: HttpAddressErrorType): string = $exc
+      func (e: HttpAddressErrorType): string = $e
     )
   else:
     let scheme =

--- a/chronos/apps/http/httpcommon.nim
+++ b/chronos/apps/http/httpcommon.nim
@@ -110,6 +110,8 @@ type
     InvalidIpHostname = "Invalid IP"
     NameLookupFailed = "DNS lookup failed"
     NoAddressResolved = "Hostname has no addresses"
+    EmptyLocationHeader = "Location header with empty value"
+    MissingLocationHeader = "Location header is missing"
 
 const
   CriticalHttpAddressError* = {
@@ -144,6 +146,10 @@ func toString*(error: HttpAddressErrorType): string =
     "Could not resolve remote address"
   of HttpAddressErrorType.NoAddressResolved:
     "No address has been resolved"
+  of HttpAddressErrorType.EmptyLocationHeader:
+    "Location header has empty value"
+  of HttpAddressErrorType.MissingLocationHeader:
+    "Location header is missing"
 
 proc raiseHttpRequestBodyTooLargeError*() {.
      noinline, noreturn, raises: [HttpRequestBodyTooLargeError].} =

--- a/chronos/apps/http/httpcommon.nim
+++ b/chronos/apps/http/httpcommon.nim
@@ -110,8 +110,6 @@ type
     InvalidIpHostname = "Invalid IP"
     NameLookupFailed = "DNS lookup failed"
     NoAddressResolved = "Hostname has no addresses"
-    EmptyLocationHeader = "Location header with empty value"
-    MissingLocationHeader = "Location header is missing"
 
 const
   CriticalHttpAddressError* = {
@@ -146,10 +144,6 @@ func toString*(error: HttpAddressErrorType): string =
     "Could not resolve remote address"
   of HttpAddressErrorType.NoAddressResolved:
     "No address has been resolved"
-  of HttpAddressErrorType.EmptyLocationHeader:
-    "Location header has empty value"
-  of HttpAddressErrorType.MissingLocationHeader:
-    "Location header is missing"
 
 proc raiseHttpRequestBodyTooLargeError*() {.
      noinline, noreturn, raises: [HttpRequestBodyTooLargeError].} =


### PR DESCRIPTION
While migrating [Nimble to Chronos](https://github.com/nim-lang/nimble/pull/1746), I bumped into a couple of these warnings:

```
/home/moigagoo/projects/nimble/vendor/chronos/chronos/apps/http/httpclient.nim(1052, 27) Warning: use getHttpAddress; getAddress is deprecated [Deprecated]
```

This PR replaces getAddress with getHttpAddress.