### PR TITLE
avoid `case` for httpversion (#677)

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "chronos"
-version       = "4.2.2"
+version       = "4.2.3"
 author        = "Status Research & Development GmbH"
 description   = "Networking framework with async/await support"
 license       = "MIT or Apache License 2.0"

--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -931,8 +931,7 @@ proc prepareResponse(
   # Preprocessing "Connection" header.
   let connectionFlag =
     block:
-      case resp.version
-      of HttpVersion11:
+      if resp.version == HttpVersion11:
         # Keeping a connection open is the default on HTTP/1.1 requests.
         # https://www.rfc-editor.org/rfc/rfc2068.html#section-19.7.1
         let header = toLowerAscii(headers.getString(ConnectionHeader))
@@ -940,7 +939,7 @@ proc prepareResponse(
           false
         else:
           true
-      of HttpVersion10:
+      elif resp.version == HttpVersion10:
         # This is the default on HTTP/1.0 requests.
         false
       else:


### PR DESCRIPTION
Use if/elif instead of case for HttpVersion comparisons to support https://github.com/status-im/nim-http-utils/pull/49