### PR TITLE
Add `send` flavor with redirect support 

### DIFF
--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -1608,6 +1608,27 @@ proc redirect*(request: HttpClientRequestRef,
     res.redirectCount = redirectCount
     ok(res)
 
+proc send*(
+    session: HttpSessionRef, url: Uri
+  ):Future[HttpClientResponseRef] {.async: (raises: [CancelledError, HttpError]).} =
+  let address = getHttpAddress(url).valueOr:
+    raiseHttpAddressError($error)
+
+  var request = HttpClientRequestRef.new(session, address)
+
+  result = await request.send()
+
+  while result.status in 300..<400:
+    let newLocation = result.getNewLocation().valueOr:
+      raise newException(HttpRequestError, error)
+
+    await result.closeWait()
+
+    request = request.redirect(newLocation).valueOr:
+      raise newException(HttpRequestError, error)
+
+    result = await request.send()
+
 proc fetch*(request: HttpClientRequestRef): Future[HttpResponseTuple] {.
      async: (raises: [CancelledError, HttpError]).} =
   var response: HttpClientResponseRef
@@ -1633,63 +1654,14 @@ proc fetch*(session: HttpSessionRef, url: Uri): Future[HttpResponseTuple] {.
   ## parameters.
   ##
   ## This procedure supports HTTP redirections.
-  let address = getHttpAddress(url).valueOr:
-    raiseHttpAddressError($error)
 
-  var
-    request = HttpClientRequestRef.new(session, address)
-    response: HttpClientResponseRef = nil
-    redirect: HttpClientRequestRef = nil
+  let
+    response = await session.send(url)
+    code = response.status
+    data = await response.getBodyBytes()
 
-  while true:
-    try:
-      response = await request.send()
-      if response.status >= 300 and response.status < 400:
-        redirect =
-          block:
-            if "location" in response.headers:
-              let location = response.headers.getString("location")
-              if len(location) > 0:
-                let res = request.redirect(parseUri(location))
-                if res.isErr():
-                  raiseHttpRedirectError(res.error())
-                res.get()
-              else:
-                raiseHttpRedirectError("Location header with an empty value")
-            else:
-              raiseHttpRedirectError("Location header missing")
-        discard await response.consumeBody()
-        await response.closeWait()
-        response = nil
-        await request.closeWait()
-        request = nil
-        request = redirect
-        redirect = nil
-      else:
-        var
-          # TODO https://github.com/status-im/nim-chronos/issues/601
-          data = await response.getBodyBytes()
-          code = response.status
-        await response.closeWait()
-        response = nil
-        await request.closeWait()
-        request = nil
-        # TODO https://github.com/nim-lang/Nim/issues/25057
-        return (code, move(data))
-    except CancelledError as exc:
-      var pending: seq[Future[void]]
-      if not(isNil(response)): pending.add(closeWait(response))
-      if not(isNil(request)): pending.add(closeWait(request))
-      if not(isNil(redirect)): pending.add(closeWait(redirect))
-      await noCancel(allFutures(pending))
-      raise exc
-    except HttpError as exc:
-      var pending: seq[Future[void]]
-      if not(isNil(response)): pending.add(closeWait(response))
-      if not(isNil(request)): pending.add(closeWait(request))
-      if not(isNil(redirect)): pending.add(closeWait(redirect))
-      await noCancel(allFutures(pending))
-      raise exc
+  await response.closeWait()
+  (code, data)
 
 proc getServerSentEvents*(
        response: HttpClientResponseRef,

--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -1611,6 +1611,53 @@ proc redirect*(request: HttpClientRequestRef,
     res.redirectCount = redirectCount
     ok(res)
 
+proc send*(session: HttpSessionRef, uri: Uri): Future[HttpClientResponseRef] {.
+     async: (raises: [CancelledError, HttpError]).} =
+  ## Send HTTP GET request to ``uri`` using ``session`` and return response.
+  ##
+  ## This procedure supports HTTP redirections.
+  let address = getHttpAddress(uri).valueOr:
+    raiseHttpAddressError($error)
+
+  var
+    request = HttpClientRequestRef.new(session, address)
+    response: HttpClientResponseRef = nil
+    redirect: HttpClientRequestRef = nil
+
+  while true:
+    try:
+      response = await request.send()
+      if response.status >= 300 and response.status < 400:
+        let location = response.getNewLocation().valueOr:
+          raiseHttpRedirectError(error)
+        redirect = request.redirect(location).valueOr:
+          raiseHttpRedirectError(error)
+
+        discard await response.consumeBody()
+        await response.closeWait()
+        response = nil
+        await request.closeWait()
+        request = nil
+        request = redirect
+        redirect = nil
+      else:
+        await request.closeWait()
+        return response
+    except CancelledError as exc:
+      var pending: seq[Future[void]]
+      if not(isNil(response)): pending.add(closeWait(response))
+      if not(isNil(request)): pending.add(closeWait(request))
+      if not(isNil(redirect)): pending.add(closeWait(redirect))
+      await noCancel(allFutures(pending))
+      raise exc
+    except HttpError as exc:
+      var pending: seq[Future[void]]
+      if not(isNil(response)): pending.add(closeWait(response))
+      if not(isNil(request)): pending.add(closeWait(request))
+      if not(isNil(redirect)): pending.add(closeWait(redirect))
+      await noCancel(allFutures(pending))
+      raise exc
+
 proc fetch*(request: HttpClientRequestRef): Future[HttpResponseTuple] {.
      async: (raises: [CancelledError, HttpError]).} =
   var response: HttpClientResponseRef
@@ -1636,55 +1683,23 @@ proc fetch*(session: HttpSessionRef, url: Uri): Future[HttpResponseTuple] {.
   ## parameters.
   ##
   ## This procedure supports HTTP redirections.
-  let address = getHttpAddress(url).valueOr:
-    raiseHttpAddressError($error)
-
-  var
-    request = HttpClientRequestRef.new(session, address)
-    response: HttpClientResponseRef = nil
-    redirect: HttpClientRequestRef = nil
-
-  while true:
-    try:
-      response = await request.send()
-      if response.status >= 300 and response.status < 400:
-        let location = response.getNewLocation().valueOr:
-          raiseHttpRedirectError(error)
-        redirect = request.redirect(location).valueOr:
-          raiseHttpRedirectError(error)
-
-        discard await response.consumeBody()
-        await response.closeWait()
-        response = nil
-        await request.closeWait()
-        request = nil
-        request = redirect
-        redirect = nil
-      else:
-        var
-          # TODO https://github.com/status-im/nim-chronos/issues/601
-          data = await response.getBodyBytes()
-          code = response.status
-        await response.closeWait()
-        response = nil
-        await request.closeWait()
-        request = nil
-        # TODO https://github.com/nim-lang/Nim/issues/25057
-        return (code, move(data))
-    except CancelledError as exc:
-      var pending: seq[Future[void]]
-      if not(isNil(response)): pending.add(closeWait(response))
-      if not(isNil(request)): pending.add(closeWait(request))
-      if not(isNil(redirect)): pending.add(closeWait(redirect))
-      await noCancel(allFutures(pending))
-      raise exc
-    except HttpError as exc:
-      var pending: seq[Future[void]]
-      if not(isNil(response)): pending.add(closeWait(response))
-      if not(isNil(request)): pending.add(closeWait(request))
-      if not(isNil(redirect)): pending.add(closeWait(redirect))
-      await noCancel(allFutures(pending))
-      raise exc
+  var response: HttpClientResponseRef = nil
+  try:
+    response = await session.send(url)
+    var
+      # TODO https://github.com/status-im/nim-chronos/issues/601
+      data = await response.getBodyBytes()
+      code = response.status
+    await response.closeWait()
+    response = nil
+    # TODO https://github.com/nim-lang/Nim/issues/25057
+    (code, move(data))
+  except CancelledError as exc:
+    if not(isNil(response)): await response.closeWait()
+    raise exc
+  except HttpError as exc:
+    if not(isNil(response)): await response.closeWait()
+    raise exc
 
 proc getServerSentEvents*(
        response: HttpClientResponseRef,

--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -1611,12 +1611,12 @@ proc redirect*(request: HttpClientRequestRef,
     res.redirectCount = redirectCount
     ok(res)
 
-proc send*(session: HttpSessionRef, uri: Uri): Future[HttpClientResponseRef] {.
+proc send*(session: HttpSessionRef, url: Uri): Future[HttpClientResponseRef] {.
      async: (raises: [CancelledError, HttpError]).} =
-  ## Send HTTP GET request to ``uri`` using ``session`` and return response.
+  ## Send HTTP GET request to ``url`` using ``session`` and return response.
   ##
   ## This procedure supports HTTP redirections.
-  let address = getHttpAddress(uri).valueOr:
+  let address = getHttpAddress(url).valueOr:
     raiseHttpAddressError($error)
 
   var

--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -1608,27 +1608,6 @@ proc redirect*(request: HttpClientRequestRef,
     res.redirectCount = redirectCount
     ok(res)
 
-proc send*(
-    session: HttpSessionRef, url: Uri
-  ):Future[HttpClientResponseRef] {.async: (raises: [CancelledError, HttpError]).} =
-  let address = getHttpAddress(url).valueOr:
-    raiseHttpAddressError($error)
-
-  var request = HttpClientRequestRef.new(session, address)
-
-  result = await request.send()
-
-  while result.status in 300..<400:
-    let newLocation = result.getNewLocation().valueOr:
-      raise newException(HttpRequestError, error)
-
-    await result.closeWait()
-
-    request = request.redirect(newLocation).valueOr:
-      raise newException(HttpRequestError, error)
-
-    result = await request.send()
-
 proc fetch*(request: HttpClientRequestRef): Future[HttpResponseTuple] {.
      async: (raises: [CancelledError, HttpError]).} =
   var response: HttpClientResponseRef
@@ -1654,14 +1633,55 @@ proc fetch*(session: HttpSessionRef, url: Uri): Future[HttpResponseTuple] {.
   ## parameters.
   ##
   ## This procedure supports HTTP redirections.
+  let address = getHttpAddress(url).valueOr:
+    raiseHttpAddressError($error)
 
-  let
-    response = await session.send(url)
-    code = response.status
-    data = await response.getBodyBytes()
+  var
+    request = HttpClientRequestRef.new(session, address)
+    response: HttpClientResponseRef = nil
+    redirect: HttpClientRequestRef = nil
 
-  await response.closeWait()
-  (code, data)
+  while true:
+    try:
+      response = await request.send()
+      if response.status >= 300 and response.status < 400:
+        let location = response.getNewLocation().valueOr:
+          raiseHttpRedirectError(error)
+        redirect = request.redirect(location).valueOr:
+          raiseHttpRedirectError(error)
+
+        discard await response.consumeBody()
+        await response.closeWait()
+        response = nil
+        await request.closeWait()
+        request = nil
+        request = redirect
+        redirect = nil
+      else:
+        var
+          # TODO https://github.com/status-im/nim-chronos/issues/601
+          data = await response.getBodyBytes()
+          code = response.status
+        await response.closeWait()
+        response = nil
+        await request.closeWait()
+        request = nil
+        # TODO https://github.com/nim-lang/Nim/issues/25057
+        return (code, move(data))
+    except CancelledError as exc:
+      var pending: seq[Future[void]]
+      if not(isNil(response)): pending.add(closeWait(response))
+      if not(isNil(request)): pending.add(closeWait(request))
+      if not(isNil(redirect)): pending.add(closeWait(redirect))
+      await noCancel(allFutures(pending))
+      raise exc
+    except HttpError as exc:
+      var pending: seq[Future[void]]
+      if not(isNil(response)): pending.add(closeWait(response))
+      if not(isNil(request)): pending.add(closeWait(request))
+      if not(isNil(redirect)): pending.add(closeWait(redirect))
+      await noCancel(allFutures(pending))
+      raise exc
 
 proc getServerSentEvents*(
        response: HttpClientResponseRef,


### PR DESCRIPTION
While migrating Nimble to Chronos for downloads ([PR](https://github.com/nim-lang/nimble/pull/1746)) I bumped into that fact that `send` doesn't handle redirects. This makes sense as `fetch`, a higher-level proc, does that. But I needed redirect support to handle streaming download so I wrote a short [helper proc](https://github.com/nim-lang/nimble/pull/1746/changes#diff-88a52bd9760eee1c465454f27d99ba4c9633de2d5a9420db17126b3f1b3bb237R453-R464).

But it would be cool to just use what Chronos provides without workarounds. So I'm adding redirect support to `send` in Chronos.

To preserve backward compatibility and make things symmetrical between `send` and `fetch`, I've added `send` that handles redirections and takes a session and a URL just like there is a `fetch` that handles redirections and takes a session and a URL.

The old `fetch` that did the redirection handling internally how uses the new `send` is has become much smaller.