### PR TITLE
Prevent nested poll calls in `async` functions

### DIFF
--- a/chronos/effects.nim
+++ b/chronos/effects.nim
@@ -6,7 +6,18 @@
 #                MIT license (LICENSE-MIT)
 type
   NestedPoll* = object of RootEffect
-    ## Nested poll calls can lead to stack space getting exhausted as well as other
-    ## kinds of undefined behavior - the event loop needs to run at top-level
-    ## and cannot be called recursively from within tasks - this is enforced
-    ## via `.forbids`
+    ## Nested poll calls are those where `poll` (or `waitFor`) is called from
+    ## within the call stack of another `poll` call - this can happen if
+    ## a call scheduled with `callSoon` gets called as part of event loop
+    ## processing, as happens with async continuations.
+    ##
+    ## Such nested calls are undefined behavior since they re-enter the event
+    ## loop and cause events to be handled out of order with respect to how
+    ## they are polled from the operating system.
+    ##
+    ## When deeply nested, it can also quickly exhaust available stack space and
+    ## cause other forms of undefined behavior.
+    ##
+    ## The nested poll effect helps prevent obvious cases of `poll` being called
+    ## inside `async` functions, though not all such calls can be detected at
+    ## compile time currently.

--- a/chronos/effects.nim
+++ b/chronos/effects.nim
@@ -1,0 +1,12 @@
+# Chronos
+#
+#  (c) Copyright 2026-Present Status Research & Development GmbH
+#                Licensed under either of
+#    Apache License, version 2.0, (LICENSE-APACHEv2)
+#                MIT license (LICENSE-MIT)
+type
+  NestedPoll* = object of RootEffect
+    ## Nested poll calls can lead to stack space getting exhausted as well as other
+    ## kinds of undefined behavior - the event loop needs to run at top-level
+    ## and cannot be called recursively from within tasks - this is enforced
+    ## via `.forbids`

--- a/chronos/futures.nim
+++ b/chronos/futures.nim
@@ -22,6 +22,8 @@ type
     Create
     Finish
 
+  # TODO forbid nested poll
+  # TODO https://github.com/nim-lang/Nim/issues/25976
   CallbackFunc* = proc (arg: pointer) {.gcsafe, raises: [].}
 
   # Internal type, not part of API

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -8,7 +8,7 @@
 #    Apache License, version 2.0, (LICENSE-APACHEv2)
 #                MIT license (LICENSE-MIT)
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 ## This module implements the core asynchronous engine / dispatcher.
 ##
@@ -17,12 +17,12 @@
 from nativesockets import Port
 import std/[tables, heapqueue, deques]
 import results
-import ".."/[config, futures, osdefs, oserrno, osutils, timer]
+import ../[config, effects, futures, osdefs, oserrno, osutils, timer]
 
 import ./[asyncmacro, errors]
 
 export Port
-export deques, errors, futures, timer, results
+export deques, effects, errors, futures, timer, results
 
 export
   asyncmacro.async, asyncmacro.await, asyncmacro.awaitne
@@ -579,7 +579,7 @@ elif defined(windows):
     if res.isErr():
       raise newException(ValueError, osErrorMsg(res.error()))
 
-  proc poll*() =
+  proc poll*() {.tags: [NestedPoll, RootEffect].} =
     let loop = getThreadDispatcher()
     var
       curTime = Moment.now()
@@ -1001,7 +1001,7 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       ## Remove process' watching using process' descriptor ``procHandle``.
       removeProcess2(procHandle).tryGet()
 
-  proc poll*() {.gcsafe.} =
+  proc poll*() {.tags: [NestedPoll, RootEffect].} =
     ## Perform single asynchronous step.
     let loop = getThreadDispatcher()
     var curTime = Moment.now()

--- a/chronos/internal/asyncmacro.nim
+++ b/chronos/internal/asyncmacro.nim
@@ -495,6 +495,12 @@ proc asyncSingleProc(prc, params: NimNode): NimNode {.compileTime.} =
     # `async` code must be gcsafe
     closureIterator.addPragma(newIdentNode("gcsafe"))
 
+    # Nesting poll calls is not allowed - we can detect this for `async` functions
+    # at least!
+    closureIterator.addPragma(
+      newColonExpr(ident "forbids", nnkBracket.newTree(ident "NestedPoll"))
+    )
+
     # Exceptions are caught inside the iterator and stored in the future
     closureIterator.addPragma(nnkExprColonExpr.newTree(
       newIdentNode("raises"),

--- a/chronos/internal/asyncmacro.nim
+++ b/chronos/internal/asyncmacro.nim
@@ -495,11 +495,13 @@ proc asyncSingleProc(prc, params: NimNode): NimNode {.compileTime.} =
     # `async` code must be gcsafe
     closureIterator.addPragma(newIdentNode("gcsafe"))
 
-    # Nesting poll calls is not allowed - we can detect this for `async` functions
-    # at least!
-    closureIterator.addPragma(
-      newColonExpr(ident "forbids", nnkBracket.newTree(ident "NestedPoll"))
-    )
+    # `forbids: [NestedPoll]` on the iterator catches calls to `poll` inside
+    # {.async.} functions - since async functions end up being called from
+    # within a poll context, they should not call `poll` themselves
+    when (NimMajor, NimMinor) >= (2, 2):
+      closureIterator.addPragma(
+        newColonExpr(ident "forbids", nnkBracket.newTree(ident "NestedPoll"))
+      )
 
     # Exceptions are caught inside the iterator and stored in the future
     closureIterator.addPragma(nnkExprColonExpr.newTree(

--- a/tests/testasyncstream.nim
+++ b/tests/testasyncstream.nim
@@ -898,12 +898,12 @@ suite "AsyncStream/ChunkedStream":
       var check = await checkVector(data, writeChunkSize, readChunkSize)
       return (data == check)
 
-    check waitFor(testChunk(4457, 128, 1)) == true
-    check waitFor(testChunk(65600, 1024, 17)) == true
-    check waitFor(testChunk(262400, 4096, 61)) == true
-    check waitFor(testChunk(767309, 4457, 173)) == true
-    check waitFor(testChunk(767309, 4457, 173)) == true
-    check waitFor(testChunk(767309, 67000, 67001)) == true
+    check await(testChunk(4457, 128, 1)) == true
+    check await(testChunk(65600, 1024, 17)) == true
+    check await(testChunk(262400, 4096, 61)) == true
+    check await(testChunk(767309, 4457, 173)) == true
+    check await(testChunk(767309, 4457, 173)) == true
+    check await(testChunk(767309, 67000, 67001)) == true
 
 suite "AsyncStream/TLSStream":
   teardown:

--- a/tests/testmacro.nim
+++ b/tests/testmacro.nim
@@ -350,7 +350,7 @@ suite "Macro transformations - implicit returns":
 
       waitFor(implicit9()) == 42
 
-suite "Closure iterator's exception transformation issues":
+suite "Exception/effect tracking":
   test "Nested defer/finally not called on return":
     # issue #288
     # fixed by https://github.com/nim-lang/Nim/pull/19933
@@ -383,7 +383,6 @@ suite "Closure iterator's exception transformation issues":
 
     waitFor(x())
 
-suite "Exceptions tracking":
   template checkNotCompiles(body: untyped) =
     check (not compiles(body))
   test "Can raise valid exception":
@@ -678,3 +677,11 @@ suite "Exceptions tracking":
     check:
       called
 
+  test "calling poll & friends in async should not be allowed":
+    check:
+      not(compiles do:
+        proc callPoll() {.async.} =
+          poll())
+      not(compiles do:
+        proc callWaitFor() {.async.} =
+          waitFor(sleepAsync(1.millis)))

--- a/tests/testmacro.nim
+++ b/tests/testmacro.nim
@@ -678,10 +678,13 @@ suite "Exception/effect tracking":
       called
 
   test "calling poll & friends in async should not be allowed":
-    check:
-      not(compiles do:
-        proc callPoll() {.async.} =
-          poll())
-      not(compiles do:
-        proc callWaitFor() {.async.} =
-          waitFor(sleepAsync(1.millis)))
+    when (NimMajor, NimMinor) >= (2, 2):
+      check:
+        not(compiles do:
+          proc callPoll() {.async.} =
+            poll())
+        not(compiles do:
+          proc callWaitFor() {.async.} =
+            waitFor(sleepAsync(1.millis)))
+    else:
+      skip()


### PR DESCRIPTION
While there seem to be limitations, we can at least catch _some_ nested waitFor calls at compile time, namely those that go through the async transformation.