### PR TITLE
Add `chronosStrictReentrancy` for runtime reentrancy detection

### DIFF
--- a/chronos.nimble
+++ b/chronos.nimble
@@ -31,7 +31,7 @@ let testArguments =
     [
       "-d:debug -d:chronosDebug -d:useSysAssert -d:useGcAssert",
       "-d:debug -d:chronosDebug -d:chronosEventEngine=poll -d:useSysAssert -d:useGcAssert",
-      "-d:release",
+      "-d:release -d:chronosPreviewV5",
     ]
 
 let cfg =

--- a/chronos/config.nim
+++ b/chronos/config.nim
@@ -4,9 +4,8 @@
 ## in transition periods leading up to a breaking release that starts enforcing
 ## them and removes the option.
 ##
-## `chronosPreviewV4` is a preview flag to enable v4 semantics - in particular,
-## it enables strict exception checking and disables parts of the deprecated
-## API and other changes being prepared for the upcoming release
+## `chronosPreviewV5` is a preview flag to enable v5 semantics - see below for
+## the strictness checks it adds.
 ##
 ## `chronosDebug` can be defined to enable several debugging helpers that come
 ## with a runtime cost - it is recommeneded to not enable these in production
@@ -35,7 +34,7 @@ const
     ##
     ## `Exception` handling may be removed in future chronos versions.
 
-  chronosStrictFutureAccess* {.booldefine.}: bool = defined(chronosPreviewV4)
+  chronosStrictFutureAccess* {.booldefine.}: bool = defined(chronosPreviewV5)
 
   chronosStackTrace* {.booldefine.}: bool = defined(chronosDebug)
     ## Include stack traces in futures for creation and completion points
@@ -111,6 +110,14 @@ const
     ## bug but it does not affect chronos' usage as long as values are not
     ## moved out of Future (at the time of writing we only move values)
 
+  chronosStrictReentrancy* {.booldefine.} = defined(chronosPreviewV5)
+    ## Raise an assert if `poll` is re-entered by calling it from an `{.async.}`
+    ## function or `callSoon` callback.
+    ##
+    ## Reentrancy is undefined behavior and generally not allowed in the chronos
+    ## runtime - enbling this option will cause a panic if it's detected - this
+    ## will become the default in future chronos versions.
+
 when defined(chronosStrictException):
   {.warning: "-d:chronosStrictException has been deprecated in favor of handleException".}
   # In chronos v3, this setting was used as the opposite of
@@ -146,4 +153,3 @@ when chronosUseSink:
 else:
   template chronosSink*(T: type): type = T
   template chronosMoveSink*(v: sink auto): untyped = v
-

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -160,7 +160,7 @@ template processCallbacks(loop: untyped) =
   when chronosStrictReentrancy:
     # Process existing callbacks but not those that follow, to allow the network
     # to regain control regularly
-    for _ in 0..<loop.callbacks.len():
+    for _ in 0 ..< len(loop.callbacks):
       let callable = loop.callbacks.popFirst()
       if not(isNil(callable.function)):
         callable.function(callable.udata)

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -157,12 +157,20 @@ template processTicks(loop: untyped) =
     loop.callbacks.addLast(loop.ticks.popFirst())
 
 template processCallbacks(loop: untyped) =
-  while true:
-    let callable = loop.callbacks.popFirst()  # len must be > 0 due to sentinel
-    if isSentinel(callable):
-      break
-    if not(isNil(callable.function)):
-      callable.function(callable.udata)
+  when chronosStrictReentrancy:
+    # Process existing callbacks but not those that follow, to allow the network
+    # to regain control regularly
+    for _ in 0..<loop.callbacks.len():
+      let callable = loop.callbacks.popFirst()
+      if not(isNil(callable.function)):
+        callable.function(callable.udata)
+  else:
+    while true:
+      let callable = loop.callbacks.popFirst()  # len must be > 0 due to sentinel
+      if isSentinel(callable):
+        break
+      if not(isNil(callable.function)):
+        callable.function(callable.udata)
 
 proc raiseAsDefect*(exc: ref Exception, msg: string) {.noreturn, noinline.} =
   # Reraise an exception as a Defect, where it's unexpected and can't be handled
@@ -347,7 +355,8 @@ elif defined(windows):
       trackers: initTable[string, TrackerBase](),
       counters: initTable[string, TrackerCounter]()
     )
-    res.callbacks.addLast(SentinelCallback)
+    when not chronosStrictReentrancy:
+      res.callbacks.addLast(SentinelCallback)
     initAPI(res)
     res
 
@@ -602,12 +611,13 @@ elif defined(windows):
       curTimeout = DWORD(0)
       events: array[MaxEventsCount, osdefs.OVERLAPPED_ENTRY]
 
-    # On reentrant `poll` calls from `processCallbacks`, e.g., `waitFor`,
-    # complete pending work of the outer `processCallbacks` call.
-    # On non-reentrant `poll` calls, this only removes sentinel element.
-    # Although reentrancy is not allowed in general, we strive not to crash
-    # if it happens, maintaining a semblance of past behavior.
-    processCallbacks(loop)
+    when not chronosStrictReentrancy:
+      # On reentrant `poll` calls from `processCallbacks`, e.g., `waitFor`,
+      # complete pending work of the outer `processCallbacks` call.
+      # On non-reentrant `poll` calls, this only removes sentinel element.
+      # Although reentrancy is not allowed in general, we strive not to crash
+      # if it happens, maintaining a semblance of past behavior.
+      processCallbacks(loop)
 
     # Moving expired timers to `loop.callbacks` and calculate timeout
     loop.processTimersGetTimeout(curTimeout)
@@ -674,13 +684,16 @@ elif defined(windows):
     # We move tick callbacks to `loop.callbacks` always.
     processTicks(loop)
 
-    # All callbacks which will be added during `processCallbacks` will be
-    # scheduled after the sentinel and are processed on next `poll()` call.
-    loop.callbacks.addLast(SentinelCallback)
+    # Process the callbacks currently scheduled - new callbacks scheduled during
+    # callback execution will run in the next poll iteration
+    when not chronosStrictReentrancy:
+      loop.callbacks.addLast(SentinelCallback)
+
     processCallbacks(loop)
 
-    # All callbacks done, skip `processCallbacks` at start.
-    loop.callbacks.addFirst(SentinelCallback)
+    when not chronosStrictReentrancy:
+      # All callbacks done, skip `processCallbacks` at start.
+      loop.callbacks.addFirst(SentinelCallback)
 
   proc closeSocket*(fd: AsyncFD, aftercb: CallbackFunc = nil) =
     ## Closes a socket and ensures that it is unregistered.
@@ -768,7 +781,8 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       trackers: initTable[string, TrackerBase](),
       counters: initTable[string, TrackerCounter]()
     )
-    res.callbacks.addLast(SentinelCallback)
+    when not chronosStrictReentrancy:
+      res.callbacks.addLast(SentinelCallback)
     initAPI(res)
     res
 
@@ -1027,12 +1041,13 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
     var curTime = Moment.now()
     var curTimeout = 0
 
-    # On reentrant `poll` calls from `processCallbacks`, e.g., `waitFor`,
-    # complete pending work of the outer `processCallbacks` call.
-    # On non-reentrant `poll` calls, this only removes sentinel element.
-    # Although reentrancy is not allowed in general, we strive not to crash
-    # if it happens, maintaining a semblance of past behavior.
-    processCallbacks(loop)
+    when not chronosStrictReentrancy:
+      # On reentrant `poll` calls from `processCallbacks`, e.g., `waitFor`,
+      # complete pending work of the outer `processCallbacks` call.
+      # On non-reentrant `poll` calls, this only removes sentinel element.
+      # Although reentrancy is not allowed in general, we strive not to crash
+      # if it happens, maintaining a semblance of past behavior.
+      processCallbacks(loop)
 
     # Moving expired timers to `loop.callbacks` and calculate timeout.
     loop.processTimersGetTimeout(curTimeout)
@@ -1083,13 +1098,17 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
     # We move tick callbacks to `loop.callbacks` always.
     processTicks(loop)
 
-    # All callbacks which will be added during `processCallbacks` will be
-    # scheduled after the sentinel and are processed on next `poll()` call.
-    loop.callbacks.addLast(SentinelCallback)
+    # Process the callbacks currently scheduled - new callbacks scheduled during
+    # callback execution will run in the next poll iteration
+
+    when not chronosStrictReentrancy:
+      loop.callbacks.addLast(SentinelCallback)
+
     processCallbacks(loop)
 
-    # All callbacks done, skip `processCallbacks` at start.
-    loop.callbacks.addFirst(SentinelCallback)
+    when not chronosStrictReentrancy:
+      # All callbacks done, skip `processCallbacks` at start.
+      loop.callbacks.addFirst(SentinelCallback)
 
 else:
   proc initAPI() = discard

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -65,6 +65,7 @@ type
     ticks*: Deque[AsyncCallback]
     trackers*: Table[string, TrackerBase]
     counters*: Table[string, TrackerCounter]
+    inEventLoop: bool
 
 proc sentinelCallbackImpl(arg: pointer) {.gcsafe, noreturn.} =
   raiseAssert "Sentinel callback MUST not be scheduled"
@@ -78,6 +79,19 @@ proc isSentinel(acb: AsyncCallback): bool =
 
 proc `<`(a, b: TimerCallback): bool =
   result = a.finishAt < b.finishAt
+
+template preparePoll(loop: PDispatcherBase) =
+  # If you hit this assert, you've called `poll`, `runForever` or `waitFor`
+  # from within an async function which is not supported due to the difficulty
+  # to control stack depth and event ordering
+  # If you're using `waitFor`, switch to `await` and / or propagate the
+  # up the call stack.
+  when chronosStrictReentrancy:
+    doAssert not loop.inEventLoop,
+      "poll, runForever and waitFor calls must not reenter / nest"
+
+  loop.inEventLoop = true
+  defer: loop.inEventLoop = false
 
 func getAsyncTimestamp*(a: Duration): auto {.inline.} =
   ## Return rounded up value of duration with milliseconds resolution.
@@ -581,6 +595,8 @@ elif defined(windows):
 
   proc poll*() {.tags: [NestedPoll, RootEffect].} =
     let loop = getThreadDispatcher()
+    loop.preparePoll()
+
     var
       curTime = Moment.now()
       curTimeout = DWORD(0)
@@ -589,6 +605,8 @@ elif defined(windows):
     # On reentrant `poll` calls from `processCallbacks`, e.g., `waitFor`,
     # complete pending work of the outer `processCallbacks` call.
     # On non-reentrant `poll` calls, this only removes sentinel element.
+    # Although reentrancy is not allowed in general, we strive not to crash
+    # if it happens, maintaining a semblance of past behavior.
     processCallbacks(loop)
 
     # Moving expired timers to `loop.callbacks` and calculate timeout
@@ -1004,12 +1022,16 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
   proc poll*() {.tags: [NestedPoll, RootEffect].} =
     ## Perform single asynchronous step.
     let loop = getThreadDispatcher()
+    loop.preparePoll()
+
     var curTime = Moment.now()
     var curTimeout = 0
 
     # On reentrant `poll` calls from `processCallbacks`, e.g., `waitFor`,
     # complete pending work of the outer `processCallbacks` call.
     # On non-reentrant `poll` calls, this only removes sentinel element.
+    # Although reentrancy is not allowed in general, we strive not to crash
+    # if it happens, maintaining a semblance of past behavior.
     processCallbacks(loop)
 
     # Moving expired timers to `loop.callbacks` and calculate timeout.

--- a/tests/testbugs.nim
+++ b/tests/testbugs.nim
@@ -112,33 +112,6 @@ suite "Asynchronous issues test suite":
       res[i] = byte(message[i mod len(message)])
     res
 
-  proc testIndexError(): Future[bool] {.async.} =
-    var server = createStreamServer(initTAddress("127.0.0.1:0"),
-                                    flags = {ReuseAddr})
-    let messageSize = DefaultStreamBufferSize * 4
-    var buffer = newSeq[byte](messageSize)
-    let msg = createBigMessage(messageSize)
-    let address = server.localAddress()
-    let afut = server.accept()
-    let outTransp = await connect(address)
-    let inpTransp = await afut
-    let bytesSent = await outTransp.write(msg)
-    check bytesSent == messageSize
-    var rfut {.used.} = inpTransp.readExactly(addr buffer[0], messageSize)
-
-    proc waiterProc(udata: pointer) {.raises: [], gcsafe.} =
-      try:
-        waitFor(sleepAsync(0.milliseconds))
-      except CatchableError:
-        raiseAssert "Unexpected exception happened"
-    let timer {.used.} = setTimer(Moment.fromNow(0.seconds), waiterProc, nil)
-    await sleepAsync(100.milliseconds)
-
-    await inpTransp.closeWait()
-    await outTransp.closeWait()
-    await server.closeWait()
-    return true
-
   proc testOrDeadlock(): Future[bool] {.async.} =
     proc f(): Future[void] {.async.} =
       await sleepAsync(2.seconds) or sleepAsync(1.seconds)
@@ -163,9 +136,6 @@ suite "Asynchronous issues test suite":
 
   test "Defer for asynchronous procedures test [Nim's issue #13899]":
     check waitFor(testDefer()) == true
-
-  test "IndexError crash test":
-    check waitFor(testIndexError()) == true
 
   test "`or` deadlock [#516] test":
     check waitFor(testOrDeadlock()) == true

--- a/tests/testmacro.nim
+++ b/tests/testmacro.nim
@@ -591,7 +591,7 @@ suite "Exception/effect tracking":
       proc unnanotated() {.async.} = raise (ref CatchableError)()
 
       checkNotCompiles:
-        proc annotated() {.async: (raises: [ValueError]).} = 
+        proc annotated() {.async: (raises: [ValueError]).} =
           raise (ref CatchableError)()
 
       checkNotCompiles:
@@ -677,7 +677,7 @@ suite "Exception/effect tracking":
     check:
       called
 
-  test "calling poll & friends in async should not be allowed":
+  test "detect poll reentrancy at compile-time in macro":
     when (NimMajor, NimMinor) >= (2, 2):
       check:
         not(compiles do:
@@ -686,5 +686,17 @@ suite "Exception/effect tracking":
         not(compiles do:
           proc callWaitFor() {.async.} =
             waitFor(sleepAsync(1.millis)))
+    else:
+      skip()
+
+  test "detect poll reentrance at runtime for other cases":
+    when chronosStrictReentrancy:
+      proc testReentrancy() {.async.} =
+        await sleepAsync(1.milliseconds)
+        poll()
+
+      let reenter = testReentrancy()
+      expect(Defect):
+        waitFor reenter
     else:
       skip()

--- a/tests/testmacro.nim
+++ b/tests/testmacro.nim
@@ -691,12 +691,10 @@ suite "Exception/effect tracking":
 
   test "detect poll reentrance at runtime for other cases":
     when chronosStrictReentrancy:
-      proc testReentrancy() {.async.} =
-        await sleepAsync(1.milliseconds)
-        poll()
+      callSoon(proc(_: pointer) =
+        poll())
 
-      let reenter = testReentrancy()
       expect(Defect):
-        waitFor reenter
+        poll()
     else:
       skip()


### PR DESCRIPTION
Reentrancy causes event reordering and stack explosions, in addition to leading to hard-to-debug scenarios.

Since none of chronos is actually tested under reentrant conditions (ie that all features such as exceptions, cancellations, buffer operations, timers etc work reliably when the loop is reentered), this is hard to support over time and prevents useful optimizations - this PR simply detects and disallows the behaviour to remove the uncertainty, simplifying reasoning about the event loop in general.