### PR TITLE
fix `Transfer-Encoding`/`Content-Encoding` parsing

### DIFF
--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -188,8 +188,10 @@ type
     reader*: HttpBodyReader
     error*: ref HttpError
     bodyFlag*: HttpClientBodyFlag
-    contentEncoding*: set[ContentEncodingFlags]
-    transferEncoding*: set[TransferEncodingFlags]
+    contentEncoding*{.deprecated.}: set[ContentEncodingFlags]
+    transferEncoding*{.deprecated.}: set[TransferEncodingFlags]
+    contentEncodings*: seq[ContentEncodingFlags]
+    transferEncodings*: seq[TransferEncodingFlags]
     contentLength*: uint64
     contentType*: Opt[ContentTypeData]
     timestamp*: Moment
@@ -906,22 +908,27 @@ proc prepareResponse(
       res
 
   # Preprocessing "Content-Encoding" header.
-  let contentEncoding =
-    block:
-      let res = getContentEncoding(headers.getList(ContentEncodingHeader))
-      if res.isErr():
-        return err("Invalid headers received, invalid `Content-Encoding`")
+  let
+    contentEncodings = getContentEncodings(headers.getList(ContentEncodingHeader)).valueOr:
+      return err("Invalid `Content-Encoding` in headers")
+    contentEncoding = {
+      if contentEncodings.len() > 0:
+        contentEncodings[^1]
       else:
-        res.get()
+        ContentEncodingFlags.Identity
+    }
 
   # Preprocessing "Transfer-Encoding" header.
-  let transferEncoding =
-    block:
-      let res = getTransferEncoding(headers.getList(TransferEncodingHeader))
-      if res.isErr():
-        return err("Invalid headers received, invalid `Transfer-Encoding`")
+  let
+    transferEncodings = getTransferEncodings(
+        headers.getList(TransferEncodingHeader)).valueOr:
+      return err("Invalid `Transfer-Encoding` in headers")
+    transferEncoding = {
+      if transferEncodings.len() > 0:
+        transferEncodings[^1]
       else:
-        res.get()
+        TransferEncodingFlags.Identity
+    }
 
   # Preprocessing "Content-Length" header.
   let (contentLength, bodyFlag) =
@@ -934,9 +941,9 @@ proc prepareResponse(
       # header
       let length = headers.getInt(ContentLengthHeader)
       (length, HttpClientBodyFlag.NoBody)
-    elif transferEncoding != {TransferEncodingFlags.Identity}:
+    elif transferEncodings.len > 0:
       # "Transfer-Encoding overrides the Content-Length"
-      if TransferEncodingFlags.Chunked in transferEncoding:
+      if transferEncodings[^1] == TransferEncodingFlags.Chunked:
         (0'u64, HttpClientBodyFlag.Chunked)
       else:
         (0'u64, HttpClientBodyFlag.Custom)
@@ -986,6 +993,7 @@ proc prepareResponse(
     reason: resp.reason(data), version: resp.version, session: request.session,
     connection: connection, headers: headers,
     contentEncoding: contentEncoding, transferEncoding: transferEncoding,
+    contentEncodings: contentEncodings, transferEncodings: transferEncodings,
     contentLength: contentLength, contentType: contentType, bodyFlag: bodyFlag
   )
 

--- a/chronos/apps/http/httpcommon.nim
+++ b/chronos/apps/http/httpcommon.nim
@@ -246,9 +246,13 @@ func getTransferEncodings*(
   ## compatibility.
   ##
   ## See also:
+  ##   * https://www.rfc-editor.org/rfc/rfc9112#section-6.1
   ##   * https://www.rfc-editor.org/rfc/rfc9110#section-8.4
   ##   * https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#transfer-coding
-  var res: seq[TransferEncodingFlags]
+  var
+    res: seq[TransferEncodingFlags]
+    chunked = 0
+
   for header in ch:
     for item in header.split(","):
       case strip(item.toLowerAscii())
@@ -256,6 +260,7 @@ func getTransferEncodings*(
         discard
       of "chunked":
         res.add(TransferEncodingFlags.Chunked)
+        inc chunked
       of "compress", "x-compress":
         res.add(TransferEncodingFlags.Compress)
       of "deflate":
@@ -264,18 +269,22 @@ func getTransferEncodings*(
         res.add(TransferEncodingFlags.Gzip)
       else:
         return err("Unsupported Transfer-Encoding value")
+
+  # Validate RFC 9112 Section 6.1 rules:
+  # 1) chunked MUST NOT appear more than once
+  # 2) if chunked is present, it MUST be the final (last) encoding
+  if chunked > 1:
+    return err("Transfer-Encoding contains duplicate chunked encoding")
+  if chunked == 1 and res[^1] != TransferEncodingFlags.Chunked:
+    return err("chunked transfer coding must be the final encoding")
+
   ok(res)
 
 func getTransferEncoding*(
        ch: openArray[string]
      ): HttpResult[set[TransferEncodingFlags]] {.deprecated: "getTransferEncodings".} =
-  ## Parse value of multiple Transfer-Encoding headers and return the last entry,
-  ## ie the encoding that must first be decoded.
-  ##
-  ## Note: for historical reasons, this function returns a `set` where in fact
-  ## it could return a single enum value.
-  # https://www.rfc-editor.org/info/rfc9110/#section-8.4
-  # https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#transfer-coding
+  ## Parse value of multiple HTTP headers ``Transfer-Encoding`` and return
+  ## the last entry, ie the first encoding that must be decoded.
   let encodings = ?getTransferEncodings(ch)
   ok {
     if encodings.len() > 0:

--- a/chronos/apps/http/httpcommon.nim
+++ b/chronos/apps/http/httpcommon.nim
@@ -237,69 +237,97 @@ iterator queryParams*(query: string,
       else:
         yield (decodeUrl(k), decodeUrl(v))
 
+func getTransferEncodings*(
+       ch: openArray[string]
+     ): HttpResult[seq[TransferEncodingFlags]] =
+  ## Parse value of multiple Transfer-Encoding headers and return the list.
+  ##
+  ## `identity` is a no-op encoding that is accepted and ignored for backwards
+  ## compatibility.
+  ##
+  ## See also:
+  ##   * https://www.rfc-editor.org/rfc/rfc9110#section-8.4
+  ##   * https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#transfer-coding
+  var res: seq[TransferEncodingFlags]
+  for header in ch:
+    for item in header.split(","):
+      case strip(item.toLowerAscii())
+      of "identity": # deprecated in HTTP/1.1+; accepted for compat
+        discard
+      of "chunked":
+        res.add(TransferEncodingFlags.Chunked)
+      of "compress", "x-compress":
+        res.add(TransferEncodingFlags.Compress)
+      of "deflate":
+        res.add(TransferEncodingFlags.Deflate)
+      of "gzip", "x-gzip":
+        res.add(TransferEncodingFlags.Gzip)
+      else:
+        return err("Unsupported Transfer-Encoding value")
+  ok(res)
+
 func getTransferEncoding*(
        ch: openArray[string]
-     ): HttpResult[set[TransferEncodingFlags]] =
-  ## Parse value of multiple HTTP headers ``Transfer-Encoding`` and return
-  ## it as set of ``TransferEncodingFlags``.
-  # TODO Transfer-Encoding is ordered, thus using a set here is wrong.
-  #      https://www.rfc-editor.org/info/rfc9112/#section-6.1
+     ): HttpResult[set[TransferEncodingFlags]] {.deprecated: "getTransferEncodings".} =
+  ## Parse value of multiple Transfer-Encoding headers and return the last entry,
+  ## ie the encoding that must first be decoded.
+  ##
+  ## Note: for historical reasons, this function returns a `set` where in fact
+  ## it could return a single enum value.
+  # https://www.rfc-editor.org/info/rfc9110/#section-8.4
   # https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#transfer-coding
-  var res: set[TransferEncodingFlags] = {}
-  if len(ch) == 0:
-    res.incl(TransferEncodingFlags.Identity)
-    ok(res)
-  else:
-    for header in ch:
-      for item in header.split(","):
-        case strip(item.toLowerAscii())
-        of "identity":
-          res.incl(TransferEncodingFlags.Identity)
-        of "chunked":
-          res.incl(TransferEncodingFlags.Chunked)
-        of "compress", "x-compress":
-          res.incl(TransferEncodingFlags.Compress)
-        of "deflate":
-          res.incl(TransferEncodingFlags.Deflate)
-        of "gzip", "x-gzip":
-          res.incl(TransferEncodingFlags.Gzip)
-        of "":
-          res.incl(TransferEncodingFlags.Identity)
-        else:
-          return err("Unsupported Transfer-Encoding value")
-    ok(res)
+  let encodings = ?getTransferEncodings(ch)
+  ok {
+    if encodings.len() > 0:
+      encodings[^1]
+    else:
+      TransferEncodingFlags.Identity
+  }
+
+func getContentEncodings*(
+       ch: openArray[string]
+     ): HttpResult[seq[ContentEncodingFlags]] =
+  ## Parse value of multiple ``Content-Encoding`` headers and return the
+  ## list of ``ContentEncodingFlags``.
+  ##
+  ## If no encodings are given, returns an empty seq.
+  ##
+  ## `identity` is a no-op encoding that is accepted and ignored for backwards
+  ## compatibility.
+  ##
+  ## See also:
+  ##   * https://www.rfc-editor.org/rfc/rfc9110#section-8.4
+  ##   * https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding
+  var res: seq[ContentEncodingFlags]
+  for header in ch:
+    for item in header.split(","):
+      case strip(item.toLowerAscii()):
+      of "identity": # valid in Accept-Encoding; accepted here for completeness
+        discard
+      of "br":
+        res.add(ContentEncodingFlags.Br)
+      of "compress", "x-compress":
+        res.add(ContentEncodingFlags.Compress)
+      of "deflate":
+        res.add(ContentEncodingFlags.Deflate)
+      of "gzip", "x-gzip":
+        res.add(ContentEncodingFlags.Gzip)
+      else:
+        return err("Unsupported Content-Encoding value")
+  ok(res)
 
 func getContentEncoding*(
        ch: openArray[string]
-     ): HttpResult[set[ContentEncodingFlags]] =
+     ): HttpResult[set[ContentEncodingFlags]] {.deprecated: "getContentEncodings".} =
   ## Parse value of multiple HTTP headers ``Content-Encoding`` and return
-  ## it as set of ``ContentEncodingFlags``.
-  # TODO Content-Encoding is ordered, thus using a set here is wrong.
-  #      https://www.rfc-editor.org/info/rfc9110/#section-8.4
-  # https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding
-  var res: set[ContentEncodingFlags] = {}
-  if len(ch) == 0:
-    res.incl(ContentEncodingFlags.Identity)
-    ok(res)
-  else:
-    for header in ch:
-      for item in header.split(","):
-        case strip(item.toLowerAscii()):
-        of "identity":
-          res.incl(ContentEncodingFlags.Identity)
-        of "br":
-          res.incl(ContentEncodingFlags.Br)
-        of "compress", "x-compress":
-          res.incl(ContentEncodingFlags.Compress)
-        of "deflate":
-          res.incl(ContentEncodingFlags.Deflate)
-        of "gzip", "x-gzip":
-          res.incl(ContentEncodingFlags.Gzip)
-        of "":
-          res.incl(ContentEncodingFlags.Identity)
-        else:
-          return err("Unsupported Content-Encoding value")
-    ok(res)
+  ## the last entry, ie the first encoding that must be decoded.
+  let encodings = ?getContentEncodings(ch)
+  ok {
+    if encodings.len() > 0:
+      encodings[^1]
+    else:
+      ContentEncodingFlags.Identity
+  }
 
 func isPersistent*(version: HttpVersion, headers: HttpTable): bool =
   if version >= HttpVersion20:

--- a/chronos/apps/http/httpserver.nim
+++ b/chronos/apps/http/httpserver.nim
@@ -484,8 +484,7 @@ proc updateRequest*(request: HttpRequestRef, scheme: string, meth: HttpMethod,
   request.contentEncodings = getContentEncodings(
     request.headers.getList(ContentEncodingHeader)
   ).valueOr:
-    let msg = "Incorrect or unsupported Content-Encoding header value"
-    return err(HttpMessage.init(Http400, msg))
+    return err(HttpMessage.init(Http400, error))
   request.contentEncoding =
     if request.contentEncodings.len() == 0:
       {ContentEncodingFlags.Identity}
@@ -496,8 +495,7 @@ proc updateRequest*(request: HttpRequestRef, scheme: string, meth: HttpMethod,
   request.transferEncodings = getTransferEncodings(
     request.headers.getList(TransferEncodingHeader)
   ).valueOr:
-    let msg = "Incorrect or unsupported Transfer-Encoding header value"
-    return err(HttpMessage.init(Http400, msg))
+    return err(HttpMessage.init(Http400, error))
   request.transferEncoding =
     if request.transferEncodings.len() == 0:
       {TransferEncodingFlags.Identity}
@@ -517,17 +515,15 @@ proc updateRequest*(request: HttpRequestRef, scheme: string, meth: HttpMethod,
         # chunked transfer coding is not the final encoding, the message body \
         # length cannot be determined reliably; the server MUST respond with the
         # 400 (Bad Request) status code
-        return err HttpMessage.init(
-          Http400, "\"chunked\" must be the final Transfer-Encoding"
-        )
+        const msg = "\"chunked\" must be the final Transfer-Encoding"
+        return err(HttpMessage.init(Http400, msg))
 
       if ContentLengthHeader in request.headers:
         # If a message is received with both a Transfer-Encoding and a
         # Content-Length header field ... Such a message ... ought to be
         # handled as an error.
-        return err HttpMessage.init(
-          Http400, "Transfer-Encoding and Content-Length must not both be present"
-        )
+        const msg = "Transfer-Encoding and Content-Length must not both be present"
+        return err(HttpMessage.init(Http400, msg))
 
       request.requestFlags.incl(HttpRequestFlags.UnboundBody)
       0
@@ -536,7 +532,7 @@ proc updateRequest*(request: HttpRequestRef, scheme: string, meth: HttpMethod,
       let length = request.headers.getInt(ContentLengthHeader)
       if length != 0:
         if request.meth == MethodTrace:
-          let msg = "TRACE requests could not have request body"
+          const msg = "TRACE requests could not have request body"
           return err(HttpMessage.init(Http400, msg))
         # Because of coversion to `int` we should avoid unexpected
         # OverflowError.
@@ -560,7 +556,7 @@ proc updateRequest*(request: HttpRequestRef, scheme: string, meth: HttpMethod,
       # Request headers has "Content-Type" header present.
       let contentType =
         getContentType(request.headers.getList(ContentTypeHeader)).valueOr:
-          let msg = "Incorrect or missing Content-Type header"
+          const msg = "Incorrect or missing Content-Type header"
           return err(HttpMessage.init(Http415, msg))
       if contentType == UrlEncodedContentType:
         request.requestFlags.incl(HttpRequestFlags.UrlencodedForm)
@@ -676,8 +672,7 @@ proc getBody*(request: HttpRequestRef): Future[seq[byte]] {.
       raiseHttpRequestBodyTooLargeError()
     res
   except AsyncStreamError as exc:
-    let msg = "Unable to read request's body, reason: " & $exc.msg
-    raiseHttpReadError(msg)
+    raiseHttpReadError("Unable to read request body: " & $exc.msg)
   finally:
     await reader.closeWait()
 
@@ -692,8 +687,7 @@ proc consumeBody*(request: HttpRequestRef): Future[void] {.
     discard await reader.consume()
     if reader.hasOverflow(): raiseHttpRequestBodyTooLargeError()
   except AsyncStreamError as exc:
-    let msg = "Unable to consume request's body, reason: " & $exc.msg
-    raiseHttpReadError(msg)
+    raiseHttpReadError("Unable to consume request body: " & $exc.msg)
   finally:
     await reader.closeWait()
 

--- a/chronos/apps/http/httpserver.nim
+++ b/chronos/apps/http/httpserver.nim
@@ -129,8 +129,10 @@ type
     scheme*: string
     version*: HttpVersion
     meth*: HttpMethod
-    contentEncoding*: set[ContentEncodingFlags]
-    transferEncoding*: set[TransferEncodingFlags]
+    contentEncoding*{.deprecated.}: set[ContentEncodingFlags]
+    transferEncoding*{.deprecated.}: set[TransferEncodingFlags]
+    contentEncodings*: seq[ContentEncodingFlags]
+    transferEncodings*: seq[TransferEncodingFlags]
     requestFlags*: set[HttpRequestFlags]
     contentLength*: int
     contentTypeData*: Opt[ContentTypeData]
@@ -475,23 +477,34 @@ proc updateRequest*(request: HttpRequestRef, scheme: string, meth: HttpMethod,
   request.headers = headers
 
   # Preprocessing "Content-Encoding" header.
+  request.contentEncodings = getContentEncodings(
+    request.headers.getList(ContentEncodingHeader)
+  ).valueOr:
+    let msg = "Incorrect or unsupported Content-Encoding header value"
+    return err(HttpMessage.init(Http400, msg))
   request.contentEncoding =
-    getContentEncoding(
-      request.headers.getList(ContentEncodingHeader)).valueOr:
-        let msg = "Incorrect or unsupported Content-Encoding header value"
-        return err(HttpMessage.init(Http400, msg))
+    if request.contentEncodings.len() == 0:
+      {ContentEncodingFlags.Identity}
+    else:
+      {request.contentEncodings[^1]}
 
   # Preprocessing "Transfer-Encoding" header.
+  request.transferEncodings = getTransferEncodings(
+    request.headers.getList(TransferEncodingHeader)
+  ).valueOr:
+    let msg = "Incorrect or unsupported Transfer-Encoding header value"
+    return err(HttpMessage.init(Http400, msg))
   request.transferEncoding =
-    getTransferEncoding(
-      request.headers.getList(TransferEncodingHeader)).valueOr:
-        let msg = "Incorrect or unsupported Transfer-Encoding header value"
-        return err(HttpMessage.init(Http400, msg))
+    if request.transferEncodings.len() == 0:
+      {TransferEncodingFlags.Identity}
+    else:
+      {request.transferEncodings[^1]}
 
   # Almost all HTTP requests could have body (except TRACE), we perform some
   # steps to reveal information about body.
   request.contentLength =
-    if TransferEncodingFlags.Chunked in request.transferEncoding:
+    if request.transferEncodings.len > 0 and
+        request.transferEncodings[^1] == TransferEncodingFlags.Chunked:
       # Request headers has "Transfer-Encoding: chunked" header present.
       if request.meth == MethodTrace:
         let msg = "TRACE requests could not have request body"
@@ -1690,8 +1703,8 @@ proc requestInfo*(req: HttpRequestRef, contentType = "text/plain"): string =
   res.add(kv("request.version", $req.version))
   res.add(kv("request.uri", $req.uri))
   res.add(kv("request.flags", $req.requestFlags))
-  res.add(kv("request.TransferEncoding", $req.transferEncoding))
-  res.add(kv("request.ContentEncoding", $req.contentEncoding))
+  res.add(kv("request.TransferEncodings", $req.transferEncodings))
+  res.add(kv("request.ContentEncodings", $req.contentEncodings))
 
   let body =
     if req.hasBody():

--- a/chronos/apps/http/httpserver.nim
+++ b/chronos/apps/http/httpserver.nim
@@ -339,8 +339,12 @@ proc getServerFlags(req: HttpRequestRef): set[HttpServerFlags] =
   req.connection.server.flags
 
 proc getResponseFlags(req: HttpRequestRef): set[HttpResponseFlags] =
+  # https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1
+  # if both Transfer-Encoding and Content-Length are present, the server MUST
+  # close the connection (potential request smuggling).
   if HttpServerFlags.Http11Pipeline in req.getServerFlags() and
-      isPersistent(req.version, req.headers):
+      isPersistent(req.version, req.headers) and
+      not(req.transferEncodings.len > 0 and ContentLengthHeader in req.headers):
     {HttpResponseFlags.KeepAlive}
   else:
     {}

--- a/chronos/apps/http/httpserver.nim
+++ b/chronos/apps/http/httpserver.nim
@@ -507,12 +507,28 @@ proc updateRequest*(request: HttpRequestRef, scheme: string, meth: HttpMethod,
   # Almost all HTTP requests could have body (except TRACE), we perform some
   # steps to reveal information about body.
   request.contentLength =
-    if request.transferEncodings.len > 0 and
-        request.transferEncodings[^1] == TransferEncodingFlags.Chunked:
-      # Request headers has "Transfer-Encoding: chunked" header present.
-      if request.meth == MethodTrace:
-        let msg = "TRACE requests could not have request body"
-        return err(HttpMessage.init(Http400, msg))
+    if request.transferEncodings.len() > 0:
+      # Request headers has "Transfer-Encoding" header present, additional
+      # conditions apply for requests:
+      # https://www.rfc-editor.org/info/rfc9112/#section-6.2
+
+      if request.transferEncodings[^1] != TransferEncodingFlags.Chunked:
+        # If a Transfer-Encoding header field is present in a request and the
+        # chunked transfer coding is not the final encoding, the message body \
+        # length cannot be determined reliably; the server MUST respond with the
+        # 400 (Bad Request) status code
+        return err HttpMessage.init(
+          Http400, "\"chunked\" must be the final Transfer-Encoding"
+        )
+
+      if ContentLengthHeader in request.headers:
+        # If a message is received with both a Transfer-Encoding and a
+        # Content-Length header field ... Such a message ... ought to be
+        # handled as an error.
+        return err HttpMessage.init(
+          Http400, "Transfer-Encoding and Content-Length must not both be present"
+        )
+
       request.requestFlags.incl(HttpRequestFlags.UnboundBody)
       0
     elif ContentLengthHeader in request.headers:
@@ -536,6 +552,9 @@ proc updateRequest*(request: HttpRequestRef, scheme: string, meth: HttpMethod,
       0
 
   if request.hasBody():
+    if request.meth == MethodTrace:
+      return err HttpMessage.init(Http400, "TRACE requests could not have request body")
+
     # If the request has a body, we will determine how it is encoded.
     if ContentTypeHeader in request.headers:
       # Request headers has "Content-Type" header present.
@@ -604,9 +623,6 @@ proc prepareRequest(conn: HttpConnectionRef,
         if table.count(ContentLengthHeader) > 1:
           return err(HttpMessage.init(Http400,
                                       "Multiple Content-Length headers"))
-        if table.count(TransferEncodingHeader) > 1:
-          return err(HttpMessage.init(Http400,
-                                      "Multuple Transfer-Encoding headers"))
         table
   ? updateRequest(request, scheme, req.meth, req.version, req.uri(), headers)
   trackCounter(HttpServerRequestTrackerName)

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -5,22 +5,20 @@
 #              Licensed under either of
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
-import ".."/chronos/config
+
+import ../chronos/config
+
+import
+  ./[
+    testmacro, testsync, testsoon, testtime, testfut, testaddress,
+    testdatagram, teststream, testserver, testbugs, testnet, testasyncstream,
+    testhttpserver, testshttpserver, testhttpclient, testratelimit,
+    testfutures, testthreadsync, testasyncsemaphore,
+  ]
 
 when (chronosEventEngine in ["epoll", "kqueue"]) or defined(windows):
-  import testmacro, testsync, testsoon, testtime, testfut, testsignal,
-         testaddress, testdatagram, teststream, testserver, testbugs, testnet,
-         testasyncstream, testhttpserver, testshttpserver, testhttpclient,
-         testproc, testratelimit, testfutures, testthreadsync, testasyncsemaphore
-
-  # Must be imported last to check for Pending futures
-  import testutils
-elif chronosEventEngine == "poll":
   # `poll` engine do not support signals and processes
-  import testmacro, testsync, testsoon, testtime, testfut, testaddress,
-         testdatagram, teststream, testserver, testbugs, testnet,
-         testasyncstream, testhttpserver, testshttpserver, testhttpclient,
-         testratelimit, testfutures, testthreadsync, testasyncsemaphore
+  import ./[testsignal, testproc]
 
   # Must be imported last to check for Pending futures
   import testutils

--- a/tests/testhttpserver.nim
+++ b/tests/testhttpserver.nim
@@ -852,108 +852,174 @@ suite "HTTP server testing suite":
       table1.count("header2") == 1
       table1.getLastString("header2") == "value4"
 
-  test "getTransferEncoding() test":
-    var encodings = [
-      "chunked", "compress", "deflate", "gzip", "identity", "x-gzip"
+  test "getTransferEncodings() test":
+    # https://www.rfc-editor.org/info/rfc9110/#section-8.4
+    # https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#transfer-coding
+    # Case-insensitive; whitespace around each item is stripped
+    # Multiple header values are combined; comma-separated values are split
+    # Empty input => []
+    # Unknown or empty (from bad separators) => error
+
+    const
+      Gz = TransferEncodingFlags.Gzip
+      Ch = TransferEncodingFlags.Chunked
+      Cc = TransferEncodingFlags.Compress
+      Df = TransferEncodingFlags.Deflate
+
+    # (input_headers, expected_ok, expected_value_or_error_msg)
+    const transferCases = [
+      # -- empty / missing --
+      (input: default(seq[string]), ok: true, value: default(seq[TransferEncodingFlags])),
+
+      # -- single header, single encoding --
+      (input: @["gzip"], ok: true, value: @[Gz]),
+      (input: @["chunked"], ok: true, value: @[Ch]),
+      (input: @["compress"], ok: true, value: @[Cc]),
+      (input: @["deflate"], ok: true, value: @[Df]),
+      (input: @["identity"], ok: true, value: @[]),
+
+      # -- single header, comma-separated --
+      (input: @["gzip, chunked"], ok: true, value: @[Gz, Ch]),
+      (input: @["gzip,chunked"], ok: true, value: @[Gz, Ch]),
+      (input: @["gzip , chunked"], ok: true, value: @[Gz, Ch]),
+      (input: @["identity, chunked, gzip"], ok: true, value: @[Ch, Gz]),
+
+      # -- multiple headers, no commas --
+      (input: @["gzip", "chunked"], ok: true, value: @[Gz, Ch]),
+
+      # -- multiple headers with comma-separated values --
+      (input: @["gzip, chunked", "compress"], ok: true, value: @[Gz, Ch, Cc]),
+
+      # -- all known values in one shot --
+      (
+        input: @["identity, chunked, compress, deflate, gzip"],
+        ok: true,
+        value: @[Ch, Cc, Df, Gz],
+      ),
+
+      # -- x-compress / x-gzip aliases --
+      (input: @["x-gzip"], ok: true, value: @[Gz]),
+      (input: @["x-compress"], ok: true, value: @[Cc]),
+      (input: @["gzip, x-gzip"], ok: true, value: @[Gz, Gz]),
+
+      # -- case insensitive --
+      (input: @["GZIP"], ok: true, value: @[Gz]),
+      (input: @["Gzip"], ok: true, value: @[Gz]),
+      (input: @["cHuNkEd"], ok: true, value: @[Ch]),
+      (input: @["COMPRESS, DEFLATE"], ok: true, value: @[Cc, Df]),
+
+      # -- whitespace only items are empty => error --
+      # (trailing comma => split produces empty item)
+      (input: @["gzip,"], ok: false, value: @[]),
+      (input: @[",gzip"], ok: false, value: @[]),
+      (input: @["gzip,,chunked"], ok: false, value: @[]),
+      (input: @[" "], ok: false, value: @[]),
+      (input: @["  ,  gzip  "], ok: false, value: @[]),
+      (input: @[""], ok: false, value: @[]),
+
+      # -- unknown transfer-encoding => error --
+      (input: @["br"], ok: false, value: @[]), # br is content-only
+      (input: @["zstd"], ok: false, value: @[]),
+      (input: @["gzip, unknown"], ok: false, value: @[]),
     ]
 
-    const FlagsVectors = [
-      {
-        TransferEncodingFlags.Identity, TransferEncodingFlags.Chunked,
-        TransferEncodingFlags.Compress, TransferEncodingFlags.Deflate,
-        TransferEncodingFlags.Gzip
-      },
-      {
-        TransferEncodingFlags.Identity, TransferEncodingFlags.Compress,
-        TransferEncodingFlags.Deflate, TransferEncodingFlags.Gzip
-      },
-      {
-        TransferEncodingFlags.Identity, TransferEncodingFlags.Deflate,
-        TransferEncodingFlags.Gzip
-      },
-      { TransferEncodingFlags.Identity, TransferEncodingFlags.Gzip },
-      { TransferEncodingFlags.Identity, TransferEncodingFlags.Gzip },
-      { TransferEncodingFlags.Gzip },
-      { TransferEncodingFlags.Identity }
+    for tc in transferCases:
+      let res = getTransferEncodings(tc.input)
+      if tc.ok:
+        checkpoint "transfer: " & tc.input.join(" || ")
+        check res.isOk()
+        check res.get() == tc.value
+        if res.get().len > 0:
+          check {res.get()[^1]} == getTransferEncoding(tc.input)[]
+      else:
+        checkpoint "transfer (expect fail): " & tc.input.join(" || ")
+        check res.isErr()
+
+  test "getContentEncodings() test":
+    # https://www.rfc-editor.org/info/rfc9110/#section-8.4
+    # https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding
+    # Note: "chunked" is a transfer-coding, NOT a content-coding => error
+    # Case-insensitive; whitespace around each item is stripped
+    # Multiple header values are combined; comma-separated values are split
+    # Empty input => []
+    # Unknown or empty (from bad separators) => error
+
+    const
+      Gz  = ContentEncodingFlags.Gzip
+      Br  = ContentEncodingFlags.Br
+      Cc  = ContentEncodingFlags.Compress
+      Df  = ContentEncodingFlags.Deflate
+
+    const contentCases = [
+      # -- empty / missing --
+      (input: default(seq[string]), ok: true, value: default(seq[ContentEncodingFlags])),
+
+      # -- single header, single encoding --
+      (input: @["gzip"], ok: true, value: @[Gz]),
+      (input: @["br"], ok: true, value: @[Br]),
+      (input: @["compress"], ok: true, value: @[Cc]),
+      (input: @["deflate"], ok: true, value: @[Df]),
+      (input: @["identity"], ok: true, value: @[]),
+
+      # -- single header, comma-separated --
+      (input: @["gzip, br"], ok: true, value: @[Gz, Br]),
+      (input: @["gzip,br"], ok: true, value: @[Gz, Br]),
+      (input: @["gzip , br"], ok: true, value: @[Gz, Br]),
+      (input: @["identity, br, gzip"], ok: true, value: @[Br, Gz]),
+
+      # -- multiple headers, no commas --
+      (input: @["gzip", "br"], ok: true, value: @[Gz, Br]),
+
+      # -- multiple headers with comma-separated values --
+      (input: @["gzip, br", "deflate"], ok: true, value: @[Gz, Br, Df]),
+
+      # -- all known values in one shot --
+      (
+        input: @["identity, br, compress, deflate, gzip"],
+        ok: true,
+        value: @[Br, Cc, Df, Gz],
+      ),
+
+      # -- x-compress / x-gzip aliases --
+      (input: @["x-gzip"], ok: true, value: @[Gz]),
+      (input: @["x-compress"], ok: true, value: @[Cc]),
+      (input: @["gzip, x-gzip"], ok: true, value: @[Gz, Gz]),
+
+      # -- case insensitive --
+      (input: @["GZIP"], ok: true, value: @[Gz]),
+      (input: @["Br"], ok: true, value: @[Br]),
+      (input: @["bR"], ok: true, value: @[Br]),
+      (input: @["COMPRESS, DEFLATE"], ok: true, value: @[Cc, Df]),
+
+      # -- whitespace only items are empty => error --
+      (input: @["gzip,"], ok: false, value: @[]),
+      (input: @[",gzip"], ok: false, value: @[]),
+      (input: @["gzip,,br"], ok: false, value: @[]),
+      (input: @[" "], ok: false, value: @[]),
+      (input: @["  ,  gzip  "], ok: false, value: @[]),
+      (input: @[""], ok: false, value: @[]),
+
+      # -- chunked is a transfer-coding, NOT content-coding => error --
+      (input: @["chunked"], ok: false, value: @[]),
+      (input: @["gzip, chunked"], ok: false, value: @[]),
+
+      # -- unknown content-encoding => error --
+      (input: @["zstd"], ok: false, value: @[]),
+      (input: @["gzip, unknown"], ok: false, value: @[]),
     ]
 
-    for i in 0 ..< 7:
-      var checkEncodings = @encodings
-      if i - 1 >= 0:
-        for k in 0 .. (i - 1):
-          checkEncodings.delete(0)
+    for tc in contentCases:
+      let res = getContentEncodings(tc.input)
+      if tc.ok:
+        checkpoint "content: " & tc.input.join(" || ")
+        check res.isOk()
+        check res.get() == tc.value
+        if res.get.len() > 0:
+          check {res.get()[^1]} == getContentEncoding(tc.input)[]
 
-      while nextPermutation(checkEncodings):
-        let res1 = getTransferEncoding([checkEncodings.join(", ")])
-        let res2 = getTransferEncoding([checkEncodings.join(",")])
-        let res3 = getTransferEncoding([checkEncodings.join("")])
-        let res4 = getTransferEncoding([checkEncodings.join(" ")])
-        let res5 = getTransferEncoding([checkEncodings.join(" , ")])
-        check:
-          res1.isOk()
-          res1.get() == FlagsVectors[i]
-          res2.isOk()
-          res2.get() == FlagsVectors[i]
-          res3.isErr()
-          res4.isErr()
-          res5.isOk()
-          res5.get() == FlagsVectors[i]
-
-    check:
-      getTransferEncoding([]).tryGet() == { TransferEncodingFlags.Identity }
-      getTransferEncoding(["", ""]).tryGet() ==
-        { TransferEncodingFlags.Identity }
-
-  test "getContentEncoding() test":
-    var encodings = [
-      "br", "compress", "deflate", "gzip", "identity", "x-gzip"
-    ]
-
-    const FlagsVectors = [
-      {
-        ContentEncodingFlags.Identity, ContentEncodingFlags.Br,
-        ContentEncodingFlags.Compress, ContentEncodingFlags.Deflate,
-        ContentEncodingFlags.Gzip
-      },
-      {
-        ContentEncodingFlags.Identity, ContentEncodingFlags.Compress,
-        ContentEncodingFlags.Deflate, ContentEncodingFlags.Gzip
-      },
-      {
-        ContentEncodingFlags.Identity, ContentEncodingFlags.Deflate,
-        ContentEncodingFlags.Gzip
-      },
-      { ContentEncodingFlags.Identity, ContentEncodingFlags.Gzip },
-      { ContentEncodingFlags.Identity, ContentEncodingFlags.Gzip },
-      { ContentEncodingFlags.Gzip },
-      { ContentEncodingFlags.Identity }
-    ]
-
-    for i in 0 ..< 7:
-      var checkEncodings = @encodings
-      if i - 1 >= 0:
-        for k in 0 .. (i - 1):
-          checkEncodings.delete(0)
-
-      while nextPermutation(checkEncodings):
-        let res1 = getContentEncoding([checkEncodings.join(", ")])
-        let res2 = getContentEncoding([checkEncodings.join(",")])
-        let res3 = getContentEncoding([checkEncodings.join("")])
-        let res4 = getContentEncoding([checkEncodings.join(" ")])
-        let res5 = getContentEncoding([checkEncodings.join(" , ")])
-        check:
-          res1.isOk()
-          res1.get() == FlagsVectors[i]
-          res2.isOk()
-          res2.get() == FlagsVectors[i]
-          res3.isErr()
-          res4.isErr()
-          res5.isOk()
-          res5.get() == FlagsVectors[i]
-
-    check:
-      getContentEncoding([]).tryGet() == { ContentEncodingFlags.Identity }
-      getContentEncoding(["", ""]).tryGet() == { ContentEncodingFlags.Identity }
+      else:
+        checkpoint "content (expect fail): " & tc.input.join(" || ")
+        check res.isErr()
 
   test "queryParams() test":
     const Vectors = [

--- a/tests/testhttpserver.nim
+++ b/tests/testhttpserver.nim
@@ -878,23 +878,33 @@ suite "HTTP server testing suite":
       (input: @["deflate"], ok: true, value: @[Df]),
       (input: @["identity"], ok: true, value: @[]),
 
-      # -- single header, comma-separated --
+      # -- single header, chunked last (RFC 9112 §6.1) --
       (input: @["gzip, chunked"], ok: true, value: @[Gz, Ch]),
       (input: @["gzip,chunked"], ok: true, value: @[Gz, Ch]),
       (input: @["gzip , chunked"], ok: true, value: @[Gz, Ch]),
-      (input: @["identity, chunked, gzip"], ok: true, value: @[Ch, Gz]),
+      (input: @["identity, chunked"], ok: true, value: @[Ch]),
 
-      # -- multiple headers, no commas --
+      # -- chunked MUST be the final encoding (RFC 9112 §6.1) --
+      (input: @["identity, chunked, gzip"], ok: false, value: @[]),
+      (input: @["chunked, gzip"], ok: false, value: @[]),
+      (input: @["gzip, chunked, gzip"], ok: false, value: @[]),
+
+      # -- multiple headers, chunked last --
       (input: @["gzip", "chunked"], ok: true, value: @[Gz, Ch]),
 
-      # -- multiple headers with comma-separated values --
-      (input: @["gzip, chunked", "compress"], ok: true, value: @[Gz, Ch, Cc]),
+      # -- chunked not last across multiple headers => error --
+      (input: @["gzip, chunked", "compress"], ok: false, value: @[]),
 
-      # -- all known values in one shot --
+      # -- multiple known encodings, chunked last --
       (
         input: @["identity, chunked, compress, deflate, gzip"],
+        ok: false,  # chunked not last
+        value: @[],
+      ),
+      (
+        input: @["gzip, compress, deflate, chunked"],
         ok: true,
-        value: @[Ch, Cc, Df, Gz],
+        value: @[Gz, Cc, Df, Ch],
       ),
 
       # -- x-compress / x-gzip aliases --
@@ -921,6 +931,13 @@ suite "HTTP server testing suite":
       (input: @["br"], ok: false, value: @[]), # br is content-only
       (input: @["zstd"], ok: false, value: @[]),
       (input: @["gzip, unknown"], ok: false, value: @[]),
+
+      # -- duplicate chunked (RFC 9112 §6.1: "chunking an already chunked
+      #    message is not allowed") => error --
+      (input: @["chunked, chunked"], ok: false, value: @[]),
+      (input: @["chunked", "chunked"], ok: false, value: @[]),
+      (input: @["gzip, chunked, gzip, chunked"], ok: false, value: @[]),
+      (input: @["chunked"], ok: true, value: @[Ch]),  # single chunked is fine
     ]
 
     for tc in transferCases:

--- a/tests/testhttpserver.nim
+++ b/tests/testhttpserver.nim
@@ -304,6 +304,26 @@ suite "HTTP server testing suite":
   asyncTest "Too big request body test (post()/multipart/chunked encoding)":
     await testTooBigBodyChunked(PostMultipartTest)
 
+  asyncTest "Both Content-Length and Transfer-Encoding preset":
+    proc process(r: RequestFence): Future[HttpResponseRef] {.
+          async: (raises: [CancelledError]).} =
+      defaultResponse()
+
+    let socketFlags = {ServerFlags.TcpNoDelay, ServerFlags.ReuseAddr}
+    let server = HttpServerRef.new(initTAddress("127.0.0.1:0"), process,
+                                socketFlags = socketFlags).expect("server")
+
+    server.start()
+    let address = server.instance.localAddress()
+
+    let request = "GET / HTTP/1.1\r\nContent-Length: 20\r\nTransfer-Encoding: chunked\r\n\r\n"
+    let data = await httpClient(address, request)
+    await server.stop()
+    await server.closeWait()
+    checkpoint data
+    check:
+      data.startsWith("HTTP/1.1 400")
+
   test "Query arguments test":
     proc testQuery(): Future[bool] {.async.} =
       var serverRes = false


### PR DESCRIPTION
Per the standard, these are encoded in the order they were applied to the content - either as comma-separated values or multiple headers (or a mix thereof)

The old `set` approach gets deprecated and we put the last encoding value in there - this is not entirely correct but at least allows correctly unpeeling one layer - in any case, any code depending on this should migrate to the `seq`.

Also, we ignore `identity` - this should only be used for `Accept-Encoding` but was incorrectly being added to the encoding set.

* error and disconnect when both transfer-encoding and content-length are present, per spec recommendation
* error and disconnect when the final transfer-encoding is present but not chunked (in the server)
