### PR TITLE
compat: disable connection reuse when pipelining flag is missing

### DIFF
--- a/chronos/apps/http/httpclient.nim
+++ b/chronos/apps/http/httpclient.nim
@@ -270,8 +270,9 @@ template isIdle(conn: HttpClientConnectionRef, timestamp: Moment,
 
 proc sessionWatcher(session: HttpSessionRef) {.async: (raises: []).}
 proc directProvider*(): HttpConnectionProvider
+
 proc new*(t: typedesc[HttpSessionRef],
-          flags: HttpClientFlags = {NewConnectionAlways},
+          flags: HttpClientFlags = {},
           maxRedirections = HttpMaxRedirections,
           connectTimeout = HttpConnectTimeout,
           headersTimeout = HttpHeadersTimeout,
@@ -290,6 +291,31 @@ proc new*(t: typedesc[HttpSessionRef],
   ## ``idleTimeout`` - timeout to consider HTTP connection as idle
   ## ``idlePeriod`` - period of time to check HTTP connections for inactivity
   doAssert(maxRedirections >= 0, "maxRedirections should not be negative")
+
+  # TODO chronos v4.2 and earlier enabled persistent connections only
+  #      together with the pipelining flag (persistent connections are
+  #      necessary but not sufficient for pipelining).
+  #
+  #      Since users of chronos (like presto and json-rpc) didn't include
+  #      pipelining in their defaults, this had the practical effect of disabling
+  #      persistent connections by default which is a good thing because the
+  #      current implementation of connection reuse in the http client is
+  #      practically unusable due to the lack of EOF monitoring (without EOF
+  #      monitoring, connections that get closed are not detected leading to
+  #      frequent request failures in most usage scenarios).
+  #
+  #      Although connection reuse is useful even without pipelining, we'll
+  #      keep using the deprecated pipelining flag as a gatekeeper so that
+  #      practically, it remains disabled in most cases - this gatekeeper
+  #      will be removed once reuse is feature complete.
+  {.push warning[Deprecated]: off.}
+  let flags =
+    if HttpClientFlag.Http11Pipeline notin flags:
+      flags + {HttpClientFlag.NewConnectionAlways}
+    else:
+      flags
+  {.pop.}
+
   let res = HttpSessionRef(
     flags: flags,
     maxRedirections: maxRedirections,
@@ -359,17 +385,20 @@ proc getHttpAddress*(
                  path: url.path, query: url.query, anchor: url.anchor,
                  username: url.username, password: url.password))
 
+{.push warning[Deprecated]: off.}
 proc getHttpAddress*(
        uri: Uri,
        flags: HttpClientFlags
      ): HttpAddressResult {.deprecated: "No DNS resolution in getHttpAddress, no flags needed".} =
   getHttpAddress(uri)
+{.pop.}
 
 proc getHttpAddress*(
        url: string,
      ): HttpAddressResult =
   getHttpAddress(parseUri(url))
 
+{.push warning[Deprecated]: off.}
 proc getHttpAddress*(
        url: string,
        flags: HttpClientFlags
@@ -388,6 +417,8 @@ proc getHttpAddress*(
      ): HttpAddressResult {.deprecated: "No DNS resolution in getHttpAddress, no session needed".} =
   ## Create new HTTP address using URL string ``url`` and .
   getHttpAddress(parseUri(url))
+
+{.pop.}
 
 proc getAddress*(session: HttpSessionRef, url: Uri): HttpResult[HttpAddress] {.deprecated: "use getHttpAddress".} =
   let res = getHttpAddress(url).valueOr:
@@ -723,7 +754,6 @@ proc reuseOrConnect(
         connection.flags.incl(HttpClientConnectionFlag.KeepAlive)
         connection.state = HttpClientConnectionState.Acquired
         return connection
-
   let connection =
     try:
       await session.connect(ha).wait(session.connectTimeout)

--- a/chronos/apps/http/httpcommon.nim
+++ b/chronos/apps/http/httpcommon.nim
@@ -150,9 +150,11 @@ proc raiseHttpRequestBodyTooLargeError*() {.
   raise (ref HttpRequestBodyTooLargeError)(
     code: Http413, msg: MaximumBodySizeError)
 
+{.push warning[Deprecated]: off.}
 proc raiseHttpCriticalError*(msg: string, code = Http400) {.
      noinline, noreturn, raises: [HttpCriticalError], deprecated.} =
   raise (ref HttpCriticalError)(code: code, msg: msg)
+{.pop.}
 
 proc raiseHttpDisconnectError*() {.
      noinline, noreturn, raises: [HttpDisconnectError].} =

--- a/tests/testhttpclient.nim
+++ b/tests/testhttpclient.nim
@@ -1025,13 +1025,13 @@ suite "HTTP client testing suite":
         d8 == @[(200, "ok", 0), (200, "ok", 0)]
 
       let
-        n1 = await test1(keepHa, HttpVersion11, {}, {})
-        n2 = await test2(keepHa, keepHa, HttpVersion11, {}, {})
+        n1 = await test1(keepHa, HttpVersion11, {HttpClientFlag.Http11Pipeline}, {})
+        n2 = await test2(keepHa, keepHa, HttpVersion11, {HttpClientFlag.Http11Pipeline}, {})
         n3 = await test1(dropHa, HttpVersion11, {}, {})
         n4 = await test2(dropHa, dropHa, HttpVersion11, {}, {})
         n5 = await test1(keepHa, HttpVersion11,
                          {HttpClientFlag.NewConnectionAlways,}, {})
-        n6 = await test1(keepHa, HttpVersion11, {},
+        n6 = await test1(keepHa, HttpVersion11, {HttpClientFlag.Http11Pipeline},
                          {HttpClientRequestFlag.DedicatedConnection})
         n7 = await test1(keepHa, HttpVersion11, {},
                          {HttpClientRequestFlag.DedicatedConnection,
@@ -1092,7 +1092,7 @@ suite "HTTP client testing suite":
     let
       address = server.instance.localAddress()
       ha = getAddress(address, HttpClientScheme.NonSecure, "/test")
-      session = HttpSessionRef.new({},
+      session = HttpSessionRef.new({HttpClientFlag.Http11Pipeline},
                                    idleTimeout = 1.seconds,
                                    idlePeriod = 200.milliseconds)
     try:


### PR DESCRIPTION
In chronos v4.2, connection reuse was enabled only together with the pipelining flag (regardlless of `NewConnectionAlways`) - this had the practical effect that it was disabled for most chronos consumers such as presto and json-rpc unless explicitly enabled by some end-user.

The above behavior is somewhat odd but practically a good thing: the implementation of connection reuse is incomplete and should not be used except in special cases due to the lack of EOF monitoring (usually via MSG_PEEK) so this change reinstates the now deprecated pipelining flag as a gatekeeper for connection reuse.

Later, when connection reuse is fully implemnted, we can also enable reuse by default.