### PR TITLE
add thread-safe dispatcher callback mechanism

### DIFF
--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -812,11 +812,6 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
         wakeupFd: array[2, cint]
       keys: seq[ReadyKey]
 
-    DispatcherHandle* = distinct (ptr typeof(PDispatcher()[]))
-      ## Dispatcher handle suitable for cross-thread use, obtainable with
-      ## `threadHandle`() - the user must take care that the dispatcher does not
-      ## get released while the handle is active.
-
   proc `==`*(x, y: AsyncFD): bool {.borrow, gcsafe.}
 
   proc globalInit() =
@@ -1318,6 +1313,11 @@ proc callSoon*(cbproc: CallbackFunc, udata: pointer = nil) =
   callSoon(AsyncCallback(function: cbproc, udata: udata))
 
 when hasThreadSupport:
+  type DispatcherHandle* = distinct (ptr typeof(PDispatcher()[]))
+    ## Dispatcher handle suitable for cross-thread use, obtainable with
+    ## `threadHandle`() - the user must take care that the dispatcher does not
+    ## get released while the handle is active.
+
   proc handle*(disp: PDispatcher): DispatcherHandle =
     DispatcherHandle(addr disp[])
 

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -704,6 +704,7 @@ elif defined(windows):
         else:
           int(eventsReceived)
 
+    var hasWakeup = false
     for i in 0 ..< networkEventsCount:
       if not(isNil(events[i].lpOverlapped)):
         var customOverlapped = PtrCustomOverlapped(events[i].lpOverlapped)
@@ -718,9 +719,13 @@ elif defined(windows):
         let acb = AsyncCallback(function: customOverlapped.data.cb,
                                 udata: cast[pointer](customOverlapped))
         loop.callbacks.addLast(acb)
+      else:
+        hasWakeup = true
 
-    # Move thread callbacks to the local callback queue
-    loop.processThreadCallbacks()
+    if hasWakeup:
+      # Move thread callbacks to the local callback queue - nil in the event
+      # queue means `wake` was called
+      loop.processThreadCallbacks()
 
     # Moving expired timers to `loop.callbacks`.
     loop.processTimers()
@@ -1151,6 +1156,7 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
     let count = loop.selector.selectInto2(curTimeout, loop.keys).valueOr:
       raiseOsDefect(error, "poll(): Unable to get OS events")
 
+    var hasWakeup = false
     for i in 0 ..< count:
       let fd = loop.keys[i].fd
       let events = loop.keys[i].events
@@ -1159,6 +1165,8 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
         if {Event.Read, Event.Error} * events != {}:
           if not isNil(adata.reader.function):
             loop.callbacks.addLast(adata.reader)
+          else:
+            hasWakeup = true
 
         if {Event.Write, Event.Error} * events != {}:
           if not isNil(adata.writer.function):
@@ -1183,15 +1191,16 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       loop.keys.setLen(min(loop.keys.len * 2, chronosEventsCount))
 
     when hasThreadSupport:
-      # Clear the wakeup flag before draining the wakeupFd
-      loop.waking.clear()
+      if hasWakeup:
+        # Clear the wakeup flag before draining the wakeupFd
+        loop.waking.clear()
 
-    # Drain the wakeup descriptor - this must be done before processing the
-    # thread callbacks since otherwise we might accidentally drain a wakeup
-    # for a callback we did not yet process
-    loop.drainWakeupFd()
+        # Drain the wakeup descriptor - this must be done before processing the
+        # thread callbacks since otherwise we might accidentally drain a wakeup
+        # for a callback we did not yet process
+        loop.drainWakeupFd()
 
-    loop.processThreadCallbacks()
+        loop.processThreadCallbacks()
 
     # Moving expired timers to `loop.callbacks`.
     loop.processTimers()

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -705,18 +705,19 @@ elif defined(windows):
           int(eventsReceived)
 
     for i in 0 ..< networkEventsCount:
-      var customOverlapped = PtrCustomOverlapped(events[i].lpOverlapped)
-      customOverlapped.data.errCode =
-        block:
-          let res = cast[uint64](customOverlapped.internal)
-          if res == 0'u64:
-            OSErrorCode(-1)
-          else:
-            OSErrorCode(rtlNtStatusToDosError(res))
-      customOverlapped.data.bytesCount = events[i].dwNumberOfBytesTransferred
-      let acb = AsyncCallback(function: customOverlapped.data.cb,
-                              udata: cast[pointer](customOverlapped))
-      loop.callbacks.addLast(acb)
+      if not(isNil(events[i].lpOverlapped)):
+        var customOverlapped = PtrCustomOverlapped(events[i].lpOverlapped)
+        customOverlapped.data.errCode =
+          block:
+            let res = cast[uint64](customOverlapped.internal)
+            if res == 0'u64:
+              OSErrorCode(-1)
+            else:
+              OSErrorCode(rtlNtStatusToDosError(res))
+        customOverlapped.data.bytesCount = events[i].dwNumberOfBytesTransferred
+        let acb = AsyncCallback(function: customOverlapped.data.cb,
+                                udata: cast[pointer](customOverlapped))
+        loop.callbacks.addLast(acb)
 
     # Move thread callbacks to the local callback queue
     loop.processThreadCallbacks()

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -15,7 +15,7 @@
 ## For more information, see the `Concepts` chapter of the guide.
 
 from nativesockets import Port
-import std/[tables, heapqueue, deques]
+import std/[atomics, tables, heapqueue, deques]
 import results
 import ../[config, effects, futures, osdefs, oserrno, osutils, timer]
 
@@ -29,6 +29,10 @@ export
 
 const
   MaxEventsCount* = 64
+  hasThreadSupport = compileOption("threads")
+
+when hasThreadSupport:
+  import ./mpsc
 
 when defined(windows):
   import std/[sets, hashes]
@@ -41,6 +45,18 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
          SIGBUS, SIGFPE, SIGKILL, SIGUSR1, SIGSEGV, SIGUSR2,
          SIGPIPE, SIGALRM, SIGTERM, SIGPIPE
   export oserrno
+
+when hasThreadSupport:
+  type
+    ThreadCallbackFunc* = proc(udata: pointer) {.nimcall, gcsafe, raises: [].}
+      ## A callback function without a closure environment that is suitable for
+      ## passing between threads
+
+    ThreadCallbackNode* = object of MpscNode
+      callback*: ThreadCallbackFunc
+      udata: pointer
+
+    ThreadCallbackQueue = MpscQueue[ThreadCallbackNode]
 
 type
   AsyncCallback* = InternalAsyncCallback
@@ -67,6 +83,10 @@ type
     counters*: Table[string, TrackerCounter]
     inEventLoop: bool
 
+    when hasThreadSupport:
+      threadCallbacks: ThreadCallbackQueue
+      waking: AtomicFlag
+
 proc sentinelCallbackImpl(arg: pointer) {.gcsafe, noreturn.} =
   raiseAssert "Sentinel callback MUST not be scheduled"
 
@@ -92,6 +112,21 @@ template preparePoll(loop: PDispatcherBase) =
 
   loop.inEventLoop = true
   defer: loop.inEventLoop = false
+
+template processThreadCallbacks(loop) =
+  # Drain cross-thread callbacks to the local callback queue
+  when hasThreadSupport:
+    while true:
+      let node = loop.threadCallbacks.pop()
+      if node == nil:
+        break
+      # Move the callbacks to the regular callback list - this ensures we don't
+      # starve the rest of the pipeline if the callbacks themselves keep adding
+      # stuff
+      loop.callbacks.addLast(
+        AsyncCallback(function: node.callback, udata: node.udata)
+      )
+      deallocShared(node)
 
 func getAsyncTimestamp*(a: Duration): auto {.inline.} =
   ## Return rounded up value of duration with milliseconds resolution.
@@ -353,10 +388,14 @@ elif defined(windows):
       idlers: initDeque[AsyncCallback](),
       ticks: initDeque[AsyncCallback](),
       trackers: initTable[string, TrackerBase](),
-      counters: initTable[string, TrackerCounter]()
+      counters: initTable[string, TrackerCounter](),
     )
     when not chronosStrictReentrancy:
       res.callbacks.addLast(SentinelCallback)
+
+    when hasThreadSupport:
+      res.threadCallbacks.init()
+
     initAPI(res)
     res
 
@@ -617,10 +656,16 @@ elif defined(windows):
       # On non-reentrant `poll` calls, this only removes sentinel element.
       # Although reentrancy is not allowed in general, we strive not to crash
       # if it happens, maintaining a semblance of past behavior.
-      processCallbacks(loop)
+      loop.processCallbacks()
 
     # Moving expired timers to `loop.callbacks` and calculate timeout
     loop.processTimersGetTimeout(curTimeout)
+
+    when hasThreadSupport:
+      # Clear the waking flag before we read the I/O port to make sure that wakeup
+      # calls after we've read the notificat but before we processed the callbacks
+      # still get posted.
+      loop.waking.clear()
 
     let networkEventsCount =
       if isNil(loop.getQueuedCompletionStatusEx):
@@ -673,6 +718,9 @@ elif defined(windows):
                               udata: cast[pointer](customOverlapped))
       loop.callbacks.addLast(acb)
 
+    # Move thread callbacks to the local callback queue
+    loop.processThreadCallbacks()
+
     # Moving expired timers to `loop.callbacks`.
     loop.processTimers()
 
@@ -682,14 +730,14 @@ elif defined(windows):
       loop.processIdlers()
 
     # We move tick callbacks to `loop.callbacks` always.
-    processTicks(loop)
+    loop.processTicks()
 
     # Process the callbacks currently scheduled - new callbacks scheduled during
     # callback execution will run in the next poll iteration
     when not chronosStrictReentrancy:
       loop.callbacks.addLast(SentinelCallback)
 
-    processCallbacks(loop)
+    loop.processCallbacks()
 
     when not chronosStrictReentrancy:
       # All callbacks done, skip `processCallbacks` at start.
@@ -752,6 +800,10 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
 
     PDispatcher* = ref object of PDispatcherBase
       selector: Selector[SelectorData]
+      when defined(linux):
+        wakeupFd: cint
+      else:
+        wakeupFd: array[2, cint]
       keys: seq[ReadyKey]
 
   proc `==`*(x, y: AsyncFD): bool {.borrow, gcsafe.}
@@ -765,12 +817,7 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
 
   proc newDispatcher*(): PDispatcher =
     ## Create new dispatcher.
-    let selector =
-      block:
-        let res = Selector.new(SelectorData)
-        if res.isErr(): raiseOsDefect(res.error(),
-                                      "Could not initialize selector")
-        res.get()
+    let selector = Selector.new(SelectorData).expect("Selector")
 
     var res = PDispatcher(
       selector: selector,
@@ -779,10 +826,41 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       idlers: initDeque[AsyncCallback](),
       keys: newSeq[ReadyKey](chronosInitialSize),
       trackers: initTable[string, TrackerBase](),
-      counters: initTable[string, TrackerCounter]()
+      counters: initTable[string, TrackerCounter](),
     )
+
     when not chronosStrictReentrancy:
       res.callbacks.addLast(SentinelCallback)
+
+    when hasThreadSupport:
+      res.threadCallbacks.init()
+
+    # Initialize the wakeup fd for waking up the event loop from other threads.
+    # On Linux: eventfd
+    # On other Unix: socketpair (portable, works on all POSIX systems)
+    when defined(linux):
+      let efd = eventfd(0, EFD_CLOEXEC or EFD_NONBLOCK)
+      if efd == -1:
+        deallocShared(cast[pointer](res))
+        raiseOsDefect(osLastError(), "newDispatcher(): Unable to create eventfd")
+
+      # Register the read end with the selector for wake-up notification
+      discard selector.registerHandle2(efd, {Event.Read}, SelectorData())
+
+      res.wakeupFd = efd
+    else:
+      var sockets: array[2, cint]
+      if socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0:
+        deallocShared(cast[pointer](res))
+        raiseOsDefect(osLastError(), "newDispatcher(): Unable to create socketpair")
+      # Make both ends non-blocking and close-on-exec
+      discard setDescriptorFlags(sockets[0], true, true)
+      discard setDescriptorFlags(sockets[1], true, true)
+
+      # Register the read end with the selector for wake-up notification
+      discard selector.registerHandle2(sockets[1], {Event.Read}, SelectorData())
+
+      res.wakeupFd = sockets
     initAPI(res)
     res
 
@@ -1033,6 +1111,22 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       ## Remove process' watching using process' descriptor ``procHandle``.
       removeProcess2(procHandle).tryGet()
 
+  template drainWakeupFd(loop: PDispatcher) =
+    # Drain any pending wakeup data from the wakeup fd. Writing to the wakeup
+    # fd (from wake()) wakes the selector/epoll/poll call. We must read the
+    # data to clear it so the next wake-up is properly detected.
+    # The draining must be done before we empty the thread callback queue.
+    when defined(linux):
+      # On linux, the read will always fully drain the descriptor
+      var dummy: uint64
+      discard handleEintr(read(loop.wakeupFd, addr dummy, sizeof(dummy)))
+    else:
+      # It's possible not everything was drained
+      var dummy: array[256, char]
+      discard handleEintr(
+        recv(SocketHandle(loop.wakeupFd[1]), addr dummy[0], cint(len(dummy)), cint(0))
+      )
+
   proc poll*() {.tags: [NestedPoll, RootEffect].} =
     ## Perform single asynchronous step.
     let loop = getThreadDispatcher()
@@ -1047,7 +1141,7 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       # On non-reentrant `poll` calls, this only removes sentinel element.
       # Although reentrancy is not allowed in general, we strive not to crash
       # if it happens, maintaining a semblance of past behavior.
-      processCallbacks(loop)
+      loop.processCallbacks()
 
     # Moving expired timers to `loop.callbacks` and calculate timeout.
     loop.processTimersGetTimeout(curTimeout)
@@ -1087,6 +1181,17 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       # batch more work in a single event loop iteration.
       loop.keys.setLen(min(loop.keys.len * 2, chronosEventsCount))
 
+    when hasThreadSupport:
+      # Clear the wakeup flag before draining the wakeupFd
+      loop.waking.clear()
+
+    # Drain the wakeup descriptor - this must be done before processing the
+    # thread callbacks since otherwise we might accidentally drain a wakeup
+    # for a callback we did not yet process
+    loop.drainWakeupFd()
+
+    loop.processThreadCallbacks()
+
     # Moving expired timers to `loop.callbacks`.
     loop.processTimers()
 
@@ -1096,7 +1201,7 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       loop.processIdlers()
 
     # We move tick callbacks to `loop.callbacks` always.
-    processTicks(loop)
+    loop.processTicks()
 
     # Process the callbacks currently scheduled - new callbacks scheduled during
     # callback execution will run in the next poll iteration
@@ -1104,7 +1209,7 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
     when not chronosStrictReentrancy:
       loop.callbacks.addLast(SentinelCallback)
 
-    processCallbacks(loop)
+    loop.processCallbacks()
 
     when not chronosStrictReentrancy:
       # All callbacks done, skip `processCallbacks` at start.
@@ -1191,15 +1296,71 @@ proc callSoon*(acb: AsyncCallback) =
   ## The callback is called when control returns to the event loop.
   getThreadDispatcher().callbacks.addLast(acb)
 
-proc callSoon*(cbproc: CallbackFunc, data: pointer) {.
-     gcsafe.} =
+proc callSoon*(cbproc: CallbackFunc, udata: pointer = nil) =
   ## Schedule `cbproc` to be called as soon as possible.
   ## The callback is called when control returns to the event loop.
   doAssert(not isNil(cbproc))
-  callSoon(AsyncCallback(function: cbproc, udata: data))
+  callSoon(AsyncCallback(function: cbproc, udata: udata))
 
-proc callSoon*(cbproc: CallbackFunc) =
-  callSoon(cbproc, nil)
+when hasThreadSupport:
+  proc wake(disp: PDispatcher) {.gcsafe, raises: [].} =
+    ## Wake up the event loop associated with dispatcher ``disp`` so that it
+    ## processes pending callbacks from the cross-thread MPSC queue.
+    ##
+    ## This procedure is **thread-safe** — it can be called from any thread.
+    ## It enqueues a sentinel node to the dispatcher's cross-thread queue
+    ## and then signals the underlying OS mechanism (epoll/kqueue/poll/IOCP)
+    ## to unblock the event loop's blocking wait.
+
+    # Signal the OS-level wait mechanism so the event loop unblocks.
+    if disp.waking.testAndSet():
+      return # There's already an in-flight wake-up call
+
+    # Wakeups are non-blocking and ignore errors, ie if it's EAGAIN or similar
+    # it means that the wakeup notification mechanism is triggered already and
+    # we don't need to trigger it again.
+
+    when defined(windows):
+      # For IOCP: post a completion status directly to the IOCP port.
+      # This is safe from any thread and will cause GetQueuedCompletionStatus
+      # to return immediately.
+      discard postQueuedCompletionStatus(disp.ioPort, DWORD(0), ULONG_PTR(0), nil)
+    elif defined(linux):
+      # For epoll: write to the eventfd so epoll_wait returns.
+      var dummy: uint64 = 1
+      discard handleEintr(write(cint(disp.wakeupFd), addr dummy, sizeof(dummy)))
+    else:
+      # For kqueue/poll: send to the socketpair so kevent/poll returns.
+      # Non-blocking send — if EAGAIN, the loop already has something to
+      # process, which is fine.
+      var dummy: uint8 = 1
+      discard handleEintr(
+        send(SocketHandle(disp.wakeupFd[0]), addr dummy, sizeof(dummy), MSG_NOSIGNAL)
+      )
+
+  proc callSoon*(disp: PDispatcher, cbproc: ThreadCallbackFunc, udata: pointer = nil) =
+    ## Schedule `cbproc` to be called as soon as possible on the thread that `disp`
+    ## belongs to.
+    ## If `disp` is the current thread dispatcher, posts directly to the
+    ## callbacks deque. Otherwise, enqueues to the cross-thread queue
+    ## for the target dispatcher's next poll cycle, waking it in the process.
+    ##
+    ## This function is thread-safe.
+    doAssert(not isNil(cbproc))
+    let current = getThreadDispatcher()
+    if current == disp:
+      # Same thread: add directly to the callbacks deque
+      disp.callbacks.addLast(AsyncCallback(function: cbproc, udata: udata))
+    else:
+      # Cross-thread: enqueue to shared MPSC queue
+      let node = createShared(ThreadCallbackNode)
+      node.callback = cbproc
+      node.udata = udata
+
+      # First push, then wake - this ensures that the callback is visible in
+      # the list by the time the processing loop gets to it.
+      disp.threadCallbacks.push(node)
+      disp.wake()
 
 proc callIdle*(acb: AsyncCallback) =
   ## Schedule ``cbproc`` to be called when there no pending network events

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -15,7 +15,7 @@
 ## For more information, see the `Concepts` chapter of the guide.
 
 from nativesockets import Port
-import std/[atomics, tables, heapqueue, deques]
+import std/[atomics, deques, heapqueue, tables, typetraits]
 import results
 import ../[config, effects, futures, osdefs, oserrno, osutils, timer]
 
@@ -812,6 +812,11 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
         wakeupFd: array[2, cint]
       keys: seq[ReadyKey]
 
+    DispatcherHandle* = distinct (ptr typeof(PDispatcher()[]))
+      ## Dispatcher handle suitable for cross-thread use, obtainable with
+      ## `threadHandle`() - the user must take care that the dispatcher does not
+      ## get released while the handle is active.
+
   proc `==`*(x, y: AsyncFD): bool {.borrow, gcsafe.}
 
   proc globalInit() =
@@ -1313,7 +1318,10 @@ proc callSoon*(cbproc: CallbackFunc, udata: pointer = nil) =
   callSoon(AsyncCallback(function: cbproc, udata: udata))
 
 when hasThreadSupport:
-  proc wake(disp: PDispatcher) {.gcsafe, raises: [].} =
+  proc handle*(disp: PDispatcher): DispatcherHandle =
+    DispatcherHandle(addr disp[])
+
+  proc wake(disp: DispatcherHandle) {.gcsafe, raises: [].} =
     ## Wake up the event loop associated with dispatcher ``disp`` so that it
     ## processes pending callbacks from the cross-thread MPSC queue.
     ##
@@ -1321,6 +1329,7 @@ when hasThreadSupport:
     ## It enqueues a sentinel node to the dispatcher's cross-thread queue
     ## and then signals the underlying OS mechanism (epoll/kqueue/poll/IOCP)
     ## to unblock the event loop's blocking wait.
+    let disp = distinctBase(disp)
 
     # Signal the OS-level wait mechanism so the event loop unblocks.
     if disp.waking.testAndSet():
@@ -1348,7 +1357,7 @@ when hasThreadSupport:
         send(SocketHandle(disp.wakeupFd[0]), addr dummy, sizeof(dummy), MSG_NOSIGNAL)
       )
 
-  proc callSoon*(disp: PDispatcher, cbproc: ThreadCallbackFunc, udata: pointer = nil) =
+  proc callSoon*(disp: DispatcherHandle, cbproc: ThreadCallbackFunc, udata: pointer = nil) =
     ## Schedule `cbproc` to be called as soon as possible on the thread that `disp`
     ## belongs to.
     ## If `disp` is the current thread dispatcher, posts directly to the
@@ -1357,10 +1366,10 @@ when hasThreadSupport:
     ##
     ## This function is thread-safe.
     doAssert(not isNil(cbproc))
-    let current = getThreadDispatcher()
-    if current == disp:
+    let current = gDisp.handle() # Don't init a new dispatcher with getThreadDispatcher()
+    if distinctBase(current) == distinctBase(disp):
       # Same thread: add directly to the callbacks deque
-      disp.callbacks.addLast(AsyncCallback(function: cbproc, udata: udata))
+      distinctBase(current).callbacks.addLast(AsyncCallback(function: cbproc, udata: udata))
     else:
       # Cross-thread: enqueue to shared MPSC queue
       let node = createShared(ThreadCallbackNode)
@@ -1369,7 +1378,7 @@ when hasThreadSupport:
 
       # First push, then wake - this ensures that the callback is visible in
       # the list by the time the processing loop gets to it.
-      disp.threadCallbacks.push(node)
+      distinctBase(disp).threadCallbacks.push(node)
       disp.wake()
 
 proc callIdle*(acb: AsyncCallback) =

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -1129,8 +1129,9 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       var dummy: uint64
       discard handleEintr(read(loop.wakeupFd, addr dummy, sizeof(dummy)))
     else:
-      # It's possible not everything was drained
-      var dummy: array[256, char]
+      # While in theory there might be more bytes to drain, it's harmless if we
+      # don't drain them all (we will get them the next loop)
+      var dummy {.noinit.}: array[64, char]
       discard handleEintr(
         recv(SocketHandle(loop.wakeupFd[1]), addr dummy[0], cint(len(dummy)), cint(0))
       )

--- a/chronos/internal/asyncengine.nim
+++ b/chronos/internal/asyncengine.nim
@@ -52,8 +52,8 @@ when hasThreadSupport:
       ## A callback function without a closure environment that is suitable for
       ## passing between threads
 
-    ThreadCallbackNode* = object of MpscNode
-      callback*: ThreadCallbackFunc
+    ThreadCallbackNode = object of MpscNode
+      callback: ThreadCallbackFunc
       udata: pointer
 
     ThreadCallbackQueue = MpscQueue[ThreadCallbackNode]
@@ -74,7 +74,7 @@ type
     opened*: uint64
     closed*: uint64
 
-  PDispatcherBase = ref object of RootRef
+  DispatcherBase = object of RootRef
     timers*: HeapQueue[TimerCallback]
     callbacks*: Deque[AsyncCallback]
     idlers*: Deque[AsyncCallback]
@@ -86,6 +86,8 @@ type
     when hasThreadSupport:
       threadCallbacks: ThreadCallbackQueue
       waking: AtomicFlag
+
+  PDispatcherBase = ref DispatcherBase
 
 proc sentinelCallbackImpl(arg: pointer) {.gcsafe, noreturn.} =
   raiseAssert "Sentinel callback MUST not be scheduled"
@@ -116,6 +118,10 @@ template preparePoll(loop: PDispatcherBase) =
 template processThreadCallbacks(loop) =
   # Drain cross-thread callbacks to the local callback queue
   when hasThreadSupport:
+    # Clear the waking flag before popping items from the queue - anything
+    # added to the queue after we start draining will result in a new wakeup
+    loop.waking.clear(moRelease)
+
     while true:
       let node = loop.threadCallbacks.pop()
       if node == nil:
@@ -274,7 +280,7 @@ elif defined(windows):
     DispatcherFlag* = enum
       SignalHandlerInstalled
 
-    PDispatcher* = ref object of PDispatcherBase
+    Dispatcher = object of DispatcherBase
       ioPort: HANDLE
       handles: HashSet[AsyncFD]
       connectEx*: WSAPROC_CONNECTEX
@@ -284,6 +290,7 @@ elif defined(windows):
       getQueuedCompletionStatusEx*: LPFN_GETQUEUEDCOMPLETIONSTATUSEX
       disconnectEx*: WSAPROC_DISCONNECTEX
       flags: set[DispatcherFlag]
+    PDispatcher* = ref Dispatcher
 
     PtrCustomOverlapped* = ptr CustomOverlapped
 
@@ -661,12 +668,6 @@ elif defined(windows):
     # Moving expired timers to `loop.callbacks` and calculate timeout
     loop.processTimersGetTimeout(curTimeout)
 
-    when hasThreadSupport:
-      # Clear the waking flag before we read the I/O port to make sure that wakeup
-      # calls after we've read the notificat but before we processed the callbacks
-      # still get posted.
-      loop.waking.clear()
-
     let networkEventsCount =
       if isNil(loop.getQueuedCompletionStatusEx):
         let res = getQueuedCompletionStatus(
@@ -804,13 +805,14 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
       reader*: AsyncCallback
       writer*: AsyncCallback
 
-    PDispatcher* = ref object of PDispatcherBase
+    Dispatcher = object of DispatcherBase
       selector: Selector[SelectorData]
       when defined(linux):
         wakeupFd: cint
       else:
         wakeupFd: array[2, cint]
       keys: seq[ReadyKey]
+    PDispatcher* = ref Dispatcher
 
   proc `==`*(x, y: AsyncFD): bool {.borrow, gcsafe.}
 
@@ -1192,14 +1194,10 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
 
     when hasThreadSupport:
       if hasWakeup:
-        # Clear the wakeup flag before draining the wakeupFd
-        loop.waking.clear()
-
         # Drain the wakeup descriptor - this must be done before processing the
         # thread callbacks since otherwise we might accidentally drain a wakeup
         # for a callback we did not yet process
         loop.drainWakeupFd()
-
         loop.processThreadCallbacks()
 
     # Moving expired timers to `loop.callbacks`.
@@ -1313,7 +1311,7 @@ proc callSoon*(cbproc: CallbackFunc, udata: pointer = nil) =
   callSoon(AsyncCallback(function: cbproc, udata: udata))
 
 when hasThreadSupport:
-  type DispatcherHandle* = distinct (ptr typeof(PDispatcher()[]))
+  type DispatcherHandle* = distinct (ptr Dispatcher)
     ## Dispatcher handle suitable for cross-thread use, obtainable with
     ## `threadHandle`() - the user must take care that the dispatcher does not
     ## get released while the handle is active.
@@ -1321,7 +1319,7 @@ when hasThreadSupport:
   proc handle*(disp: PDispatcher): DispatcherHandle =
     DispatcherHandle(addr disp[])
 
-  proc wake(disp: DispatcherHandle) {.gcsafe, raises: [].} =
+  proc wake(disp: ptr Dispatcher) =
     ## Wake up the event loop associated with dispatcher ``disp`` so that it
     ## processes pending callbacks from the cross-thread MPSC queue.
     ##
@@ -1329,11 +1327,6 @@ when hasThreadSupport:
     ## It enqueues a sentinel node to the dispatcher's cross-thread queue
     ## and then signals the underlying OS mechanism (epoll/kqueue/poll/IOCP)
     ## to unblock the event loop's blocking wait.
-    let disp = distinctBase(disp)
-
-    # Signal the OS-level wait mechanism so the event loop unblocks.
-    if disp.waking.testAndSet():
-      return # There's already an in-flight wake-up call
 
     # Wakeups are non-blocking and ignore errors, ie if it's EAGAIN or similar
     # it means that the wakeup notification mechanism is triggered already and
@@ -1376,10 +1369,15 @@ when hasThreadSupport:
       node.callback = cbproc
       node.udata = udata
 
+      let disp = distinctBase(disp)
       # First push, then wake - this ensures that the callback is visible in
       # the list by the time the processing loop gets to it.
-      distinctBase(disp).threadCallbacks.push(node)
-      disp.wake()
+      disp.threadCallbacks.push(node)
+
+      # Since we draing the mpsc queue on wake-up, we only need one wakeup
+      # notification per batch of queue writes
+      if not disp.waking.testAndSet(moAcquireRelease):
+        disp.wake()
 
 proc callIdle*(acb: AsyncCallback) =
   ## Schedule ``cbproc`` to be called when there no pending network events

--- a/chronos/internal/mpsc.nim
+++ b/chronos/internal/mpsc.nim
@@ -1,0 +1,90 @@
+#                     Chronos
+#
+#  (c) Copyright 2026-Present Status Research & Development GmbH
+#
+#                Licensed under either of
+#    Apache License, version 2.0, (LICENSE-APACHEv2)
+#                MIT license (LICENSE-MIT)
+
+## Intrusive multi-producer, single-consumer linked list courtesy of D.Vyukov:
+##
+## https://groups.google.com/g/lock-free/c/Vd9xuHrLggE/m/B9-URa3B37MJ
+##
+## https://github.com/grivet/mpsc-queue/blob/main/mpsc-queue.h is a modernised
+## version thereof upon which this implementation is based.
+
+{.push raises: [], gcsafe.}
+
+import std/atomics
+
+type
+  MpscNode* {.inheritable, pure.} = object
+    ## Base node type. All node types used with ``MpscQueue`` should embed
+    ## or inherit from this, or at minimum have an ``Atomic[ptr MpscNode]``
+    ## field named ``next``.
+    next*: Atomic[ptr MpscNode]
+
+  MpscQueue*[T] = object
+    ## Lock-free Michael & Scott MPSC queue parameterized by node type ``T``.
+    ##
+    ## ``T`` must have an ``Atomic[ptr T]`` field called ``next`` (which
+    ## is naturally the case if ``T`` embeds ``MpscNode`` or declares its
+    ## own ``next`` field of the right type).
+    head: Atomic[ptr MpscNode]
+    tail: Atomic[ptr MpscNode]
+    stub: MpscNode
+
+# We need the `stub` pointer to be stable after init so neither moves nor copies
+# are permissible
+proc `=copy`[T](a: var MpscQueue[T], b: MpscQueue[T]) {.error.}
+proc `=move`[T](a: var MpscQueue[T], b: MpscQueue[T]) {.error.}
+
+proc init*[T](q: var MpscQueue[T]) =
+  ## Initialize the queue - must be called before any other ops
+
+  q.head.store(addr q.stub, moRelaxed)
+  q.tail.store(addr q.stub, moRelaxed)
+  q.stub.next.store(nil, moRelaxed)
+
+proc push*[T](q: var MpscQueue[T], node: ptr T) =
+  ## Push a node into the queue - may be called concurrently by multiple
+  ## producers.
+  node[].next.store(nil, moRelaxed)
+
+  let prev = q.head.exchange(node, moAcquireRelease)
+  prev[].next.store(node, moRelease)
+
+proc pop*[T](q: var MpscQueue[T]): ptr T =
+  ## Try to pop the next node. Returns ``true`` if an item was popped,
+  ## and ``nil`` otherwise.
+  ##
+  ## Only a single consumer may call this function concurrently.
+  while true:
+    var
+      tail = q.tail.load(moRelaxed)
+      next = tail.next.load(moAcquire)
+
+    if tail == addr q.stub:
+      if next == nil:
+        if tail != q.head.load(moAcquire):
+          continue
+
+        return nil
+
+      q.tail.store(next, moRelaxed)
+      tail = next
+      next = tail.next.load(moAcquire)
+
+    if next != nil:
+      q.tail.store(next, moRelaxed)
+      return (ptr T)(tail)
+
+    if tail != q.head.load(moAcquire):
+      continue
+
+    q.push(cast[ptr T](addr q.stub))
+
+    next = tail.next.load(moAcquire)
+    if next != nil:
+      q.tail.store(next, moRelaxed)
+      return (ptr T)(tail)

--- a/chronos/internal/mpsc.nim
+++ b/chronos/internal/mpsc.nim
@@ -37,7 +37,7 @@ type
 # We need the `stub` pointer to be stable after init so neither moves nor copies
 # are permissible
 proc `=copy`[T](a: var MpscQueue[T], b: MpscQueue[T]) {.error.}
-proc `=move`[T](a: var MpscQueue[T], b: MpscQueue[T]) {.error.}
+proc `=sink`[T](a: var MpscQueue[T], b: MpscQueue[T]) {.error.}
 
 proc init*[T](q: var MpscQueue[T]) =
   ## Initialize the queue - must be called before any other ops

--- a/chronos/streams/asyncstream.nim
+++ b/chronos/streams/asyncstream.nim
@@ -1243,7 +1243,9 @@ proc newAsyncStreamReader*(rsource: AsyncStreamReader,
   ##
   ## ``bufferSize`` is internal buffer size.
   var res = AsyncStreamReader()
+  {.push warning[Deprecated]: off.}
   res.init(rsource, loop, bufferSize)
+  {.pop.}
   res
 
 proc newAsyncStreamReader*[T](tsource: StreamTransport,
@@ -1255,7 +1257,9 @@ proc newAsyncStreamReader*[T](tsource: StreamTransport,
   ## ``udata`` - user object which will be associated with new AsyncStreamWriter
   ## object.
   var res = AsyncStreamReader()
+  {.push warning[Deprecated]: off.}
   res.init(tsource, udata)
+  {.pop.}
   res
 
 proc newAsyncStreamReader*(tsource: StreamTransport): AsyncStreamReader =
@@ -1311,7 +1315,9 @@ proc newAsyncStreamWriter*(wsource: AsyncStreamWriter,
   ##
   ## ``queueSize`` is writing queue size (default size is unlimited).
   var res = AsyncStreamWriter()
+  {.push warning[Deprecated]: off.}
   res.init(wsource, loop, queueSize)
+  {.pop.}
   res
 
 proc newAsyncStreamWriter*[T](tsource: StreamTransport,
@@ -1323,7 +1329,9 @@ proc newAsyncStreamWriter*[T](tsource: StreamTransport,
   ## ``udata`` - user object which will be associated with new AsyncStreamWriter
   ## object.
   var res = AsyncStreamWriter()
+  {.push warning[Deprecated]: off.}
   res.init(tsource, udata)
+  {.pop.}
   res
 
 proc newAsyncStreamWriter*(tsource: StreamTransport): AsyncStreamWriter =

--- a/chronos/threadsync.nim
+++ b/chronos/threadsync.nim
@@ -15,7 +15,7 @@ export results
 
 {.push raises: [].}
 
-const hasThreadSupport* = compileOption("threads")
+const hasThreadSupport = compileOption("threads")
 when not(hasThreadSupport):
   {.fatal: "Compile this program with threads enabled!".}
 

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -10,10 +10,10 @@ import ../chronos/config
 
 import
   ./[
-    testmacro, testsync, testsoon, testtime, testfut, testaddress,
-    testdatagram, teststream, testserver, testbugs, testnet, testasyncstream,
-    testhttpserver, testshttpserver, testhttpclient, testratelimit,
-    testfutures, testthreadsync, testasyncsemaphore,
+    testmacro, testsync, testsoon, testtime, testfut, testaddress, testdatagram,
+    teststream, testserver, testbugs, testnet, testasyncstream, testhttpserver,
+    testshttpserver, testhttpclient, testratelimit, testfutures, testthreadsync,
+    testasyncsemaphore, testmpsc,
   ]
 
 when (chronosEventEngine in ["epoll", "kqueue"]) or defined(windows):

--- a/tests/testfut.nim
+++ b/tests/testfut.nim
@@ -2923,3 +2923,24 @@ suite "Future[T] behavior test suite":
       completed = waitFor fut.withTimeout(10.seconds)
     check completed
     check fut.completed()
+
+  test "cross-thread callSoon() test":
+    var crossThreadCallSoonFlag = false
+    proc crossThreadCallSoonCallback(udata: pointer) {.nimcall, gcsafe, raises: [].} =
+      cast[ptr bool](udata)[] = true
+    type T = (DispatcherHandle, ptr bool)
+    proc threadProc(disp: T) {.thread, nimcall.} =
+      callSoon(disp[0], crossThreadCallSoonCallback, disp[1])
+      callSoon(disp[0], crossThreadCallSoonCallback, disp[1])
+
+    # Pass the current thread's dispatcher pointer to a new thread
+    crossThreadCallSoonFlag = false
+    let disp = getThreadDispatcher()
+    var thread: Thread[T]
+    createThread(thread, threadProc, (disp.handle(), addr crossThreadCallSoonFlag))
+
+    # The callback was posted to the dispatcher's queue; poll to execute it
+    poll()
+    check: crossThreadCallSoonFlag == true
+    joinThreads(thread)
+    checkLeaks()

--- a/tests/testfut.nim
+++ b/tests/testfut.nim
@@ -2923,24 +2923,3 @@ suite "Future[T] behavior test suite":
       completed = waitFor fut.withTimeout(10.seconds)
     check completed
     check fut.completed()
-
-  test "cross-thread callSoon() test":
-    var crossThreadCallSoonFlag = false
-    proc crossThreadCallSoonCallback(udata: pointer) {.nimcall, gcsafe, raises: [].} =
-      cast[ptr bool](udata)[] = true
-    type T = (DispatcherHandle, ptr bool)
-    proc threadProc(disp: T) {.thread, nimcall.} =
-      callSoon(disp[0], crossThreadCallSoonCallback, disp[1])
-      callSoon(disp[0], crossThreadCallSoonCallback, disp[1])
-
-    # Pass the current thread's dispatcher pointer to a new thread
-    crossThreadCallSoonFlag = false
-    let disp = getThreadDispatcher()
-    var thread: Thread[T]
-    createThread(thread, threadProc, (disp.handle(), addr crossThreadCallSoonFlag))
-
-    # The callback was posted to the dispatcher's queue; poll to execute it
-    poll()
-    check: crossThreadCallSoonFlag == true
-    joinThreads(thread)
-    checkLeaks()

--- a/tests/testmpsc.nim
+++ b/tests/testmpsc.nim
@@ -175,74 +175,81 @@ suite "MPSC stress test":
     check total == Producers * ItemsPerProducer
 
   test "100000 items with 100 producers":
-    const Producers = 100
-    const ItemsPerProducer = 1000
+    when defined(gcOrc):
+      skip()
+    else:
+      const Producers = 100
+      const ItemsPerProducer = 1000
 
-    type ProdArg = object
-      q: ptr MpscQueue[TestNode]
-      startId: int
+      type ProdArg = object
+        q: ptr MpscQueue[TestNode]
+        startId: int
 
-    var threads = newSeq[Thread[ProdArg]](Producers)
+      var threads = newSeq[Thread[ProdArg]](Producers)
 
-    proc producer(arg: ProdArg) {.thread.} =
-      for i in 0 ..< ItemsPerProducer:
-        let node = newTestNode(arg.startId * ItemsPerProducer + i)
-        arg.q[].push(node)
+      proc producer(arg: ProdArg) {.thread.} =
+        for i in 0 ..< ItemsPerProducer:
+          let node = newTestNode(arg.startId * ItemsPerProducer + i)
+          arg.q[].push(node)
 
-    for i in 0 ..< Producers:
-      let arg = ProdArg(q: addr q, startId: i)
-      createThread(threads[i], producer, arg)
+      for i in 0 ..< Producers:
+        let arg = ProdArg(q: addr q, startId: i)
+        createThread(threads[i], producer, arg)
 
-    # Wait for all producers
-    joinThreads(threads)
+      # Wait for all producers
+      joinThreads(threads)
 
-    # Drain and verify
-    var total = 0
-    while true:
-      let node = q.pop()
-      if node == nil:
-        break
-      deallocShared(node)
-      inc total
+      # Drain and verify
+      var total = 0
+      while true:
+        let node = q.pop()
+        if node == nil:
+          break
+        deallocShared(node)
+        inc total
 
-    check total == Producers * ItemsPerProducer
+      check total == Producers * ItemsPerProducer
 
   test "concurrent producers with busy-loop consumer":
-    # Producers push items while a single consumer busy-loops,
-    # calling pop() until it has received the expected total.
-    const Producers = 8
-    const ItemsPerProducer = 5000
-    const TotalItems = Producers * ItemsPerProducer
+    when defined(gcOrc):
+      # TODO https://github.com/nim-lang/Nim/issues/26014
+      skip()
+    else:      
+      # Producers push items while a single consumer busy-loops,
+      # calling pop() until it has received the expected total.
+      const Producers = 8
+      const ItemsPerProducer = 5000
+      const TotalItems = Producers * ItemsPerProducer
 
-    type ProdArg = object
-      q: ptr MpscQueue[TestNode]
-      startId: int
+      type ProdArg = object
+        q: ptr MpscQueue[TestNode]
+        startId: int
 
-    var threads = newSeq[Thread[ProdArg]](Producers)
+      var threads = newSeq[Thread[ProdArg]](Producers)
 
-    proc producer(arg: ProdArg) {.thread.} =
-      for i in 0 ..< ItemsPerProducer:
-        let node = newTestNode(arg.startId * ItemsPerProducer + i)
-        arg.q[].push(node)
+      proc producer(arg: ProdArg) {.thread.} =
+        for i in 0 ..< ItemsPerProducer:
+          let node = newTestNode(arg.startId * ItemsPerProducer + i)
+          arg.q[].push(node)
 
-    # Spawn producers
-    for i in 0 ..< Producers:
-      let arg = ProdArg(q: addr q, startId: i)
-      createThread(threads[i], producer, arg)
+      # Spawn producers
+      for i in 0 ..< Producers:
+        let arg = ProdArg(q: addr q, startId: i)
+        createThread(threads[i], producer, arg)
 
-    # Consumer busy-loops: keep calling pop() concurrently with the
-    # producers until we've collected the expected number of items.
-    var total = 0
-    while total < TotalItems:
-      let node = q.pop()
-      if node != nil:
-        check node[].value < TotalItems
-        check node[].value >= 0
-        inc total
-        deallocShared(node)
-      # On nil we simply retry (busy-loop)
+      # Consumer busy-loops: keep calling pop() concurrently with the
+      # producers until we've collected the expected number of items.
+      var total = 0
+      while total < TotalItems:
+        let node = q.pop()
+        if node != nil:
+          check node[].value < TotalItems
+          check node[].value >= 0
+          inc total
+          deallocShared(node)
+        # On nil we simply retry (busy-loop)
 
-    # All producers must have finished by now
-    joinThreads(threads)
+      # All producers must have finished by now
+      joinThreads(threads)
 
-    check total == TotalItems
+      check total == TotalItems

--- a/tests/testmpsc.nim
+++ b/tests/testmpsc.nim
@@ -1,0 +1,248 @@
+#                Chronos Test Suite
+#            (c) Copyright 2026-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+import unittest2, ../chronos/internal/mpsc
+
+{.used.}
+
+type
+  TestNode = object of MpscNode
+    value: int
+
+  MpscTestQueue = MpscQueue[TestNode]
+
+proc newTestNode(v: int): ptr TestNode =
+  result = createShared(TestNode)
+  result[].value = v
+
+suite "MPSC semantics":
+  test "single push and pop":
+    var q: MpscTestQueue
+    q.init()
+    let node = newTestNode(42)
+    q.push(node)
+
+    let popped = q.pop()
+    check popped != nil
+    check popped[].value == 42
+
+  test "multiple push and FIFO pop":
+    var q: MpscTestQueue
+    q.init()
+    let n1 = newTestNode(1)
+    let n2 = newTestNode(2)
+    let n3 = newTestNode(3)
+    q.push(n1)
+    q.push(n2)
+    q.push(n3)
+
+    check q.pop()[].value == 1
+    check q.pop()[].value == 2
+    check q.pop()[].value == 3
+    check q.pop() == nil # Queue is empty
+
+    deallocShared(n1)
+    deallocShared(n2)
+    deallocShared(n3)
+
+  test "pop on empty queue":
+    var q: MpscTestQueue
+    q.init()
+    check q.pop() == nil
+
+  test "pop non-blocking drain":
+    var q: MpscTestQueue
+    q.init()
+
+    # Push some items
+    var nodes = newSeq[ptr TestNode]()
+    for i in 0 ..< 100:
+      let node = newTestNode(i)
+      nodes.add(node)
+      q.push(node)
+
+    # Drain using pop
+    var total = 0
+    while true:
+      let node = q.pop()
+      if node == nil:
+        break
+      check node[].value == total
+      inc total
+
+    check total == 100
+    # After draining all items, pop should return nil
+    check q.pop() == nil
+
+    # Free all nodes
+    for n in nodes:
+      deallocShared(n)
+
+suite "MPSC stress test":
+  setup:
+    var q: MpscQueue[TestNode]
+    q.init()
+
+  test "10000 push/pop":
+    const count = 10000
+    var nodes = newSeq[ptr TestNode](count)
+
+    # Push all
+    for i in 0 ..< count:
+      nodes[i] = newTestNode(i)
+      q.push(nodes[i])
+
+    # Pop all
+    for i in 0 ..< count:
+      let node = q.pop()
+      check node != nil
+      check node[].value == i
+
+    check q.pop() == nil # Queue is empty
+
+    # Cleanup
+    for node in nodes:
+      deallocShared(node)
+
+  test "interleaved push/pop":
+    var nodes = newSeq[ptr TestNode]()
+    var popIdx = 0
+
+    for i in 0 ..< 1000:
+      let node = newTestNode(i)
+      nodes.add(node)
+      q.push(node)
+
+      # Pop every other one
+      if i mod 2 == 0:
+        let popped = q.pop()
+        check popped != nil
+        check popped[].value == popIdx
+        inc popIdx
+
+    # Drain remaining
+    while true:
+      let node = q.pop()
+      if node == nil:
+        break
+      check node[].value == popIdx
+      inc popIdx
+
+    check popIdx == 1000 # All 1000 items were popped
+
+    # Free all nodes
+    for n in nodes:
+      deallocShared(n)
+
+  test "multiple producers, single consumer":
+    const Producers = 8
+    const ItemsPerProducer = 10000
+
+    type ProdArg = object
+      q: ptr MpscQueue[TestNode]
+      startId: int
+
+    var threads = newSeq[Thread[ProdArg]](Producers)
+
+    proc producer(arg: ProdArg) {.thread.} =
+      for i in 0 ..< ItemsPerProducer:
+        let node = newTestNode(arg.startId * ItemsPerProducer + i)
+        arg.q[].push(node)
+
+    for i in 0 ..< Producers:
+      let arg = ProdArg(q: addr q, startId: i)
+      createThread(threads[i], producer, arg)
+
+    # Wait for all producers
+    joinThreads(threads)
+
+    # Verify all items were pushed
+    var total = 0
+    while true:
+      let node = q.pop()
+      if node == nil:
+        break
+      check node[].value >= 0
+      check node[].value < Producers * ItemsPerProducer
+      deallocShared(node)
+      inc total
+
+    check total == Producers * ItemsPerProducer
+
+  test "100000 items with 100 producers":
+    const Producers = 100
+    const ItemsPerProducer = 1000
+
+    type ProdArg = object
+      q: ptr MpscQueue[TestNode]
+      startId: int
+
+    var threads = newSeq[Thread[ProdArg]](Producers)
+
+    proc producer(arg: ProdArg) {.thread.} =
+      for i in 0 ..< ItemsPerProducer:
+        let node = newTestNode(arg.startId * ItemsPerProducer + i)
+        arg.q[].push(node)
+
+    for i in 0 ..< Producers:
+      let arg = ProdArg(q: addr q, startId: i)
+      createThread(threads[i], producer, arg)
+
+    # Wait for all producers
+    joinThreads(threads)
+
+    # Drain and verify
+    var total = 0
+    while true:
+      let node = q.pop()
+      if node == nil:
+        break
+      deallocShared(node)
+      inc total
+
+    check total == Producers * ItemsPerProducer
+
+  test "concurrent producers with busy-loop consumer":
+    # Producers push items while a single consumer busy-loops,
+    # calling pop() until it has received the expected total.
+    const Producers = 8
+    const ItemsPerProducer = 5000
+    const TotalItems = Producers * ItemsPerProducer
+
+    type ProdArg = object
+      q: ptr MpscQueue[TestNode]
+      startId: int
+
+    var threads = newSeq[Thread[ProdArg]](Producers)
+
+    proc producer(arg: ProdArg) {.thread.} =
+      for i in 0 ..< ItemsPerProducer:
+        let node = newTestNode(arg.startId * ItemsPerProducer + i)
+        arg.q[].push(node)
+
+    # Spawn producers
+    for i in 0 ..< Producers:
+      let arg = ProdArg(q: addr q, startId: i)
+      createThread(threads[i], producer, arg)
+
+    # Consumer busy-loops: keep calling pop() concurrently with the
+    # producers until we've collected the expected number of items.
+    var total = 0
+    while total < TotalItems:
+      let node = q.pop()
+      if node != nil:
+        check node[].value < TotalItems
+        check node[].value >= 0
+        inc total
+        deallocShared(node)
+      # On nil we simply retry (busy-loop)
+
+    # All producers must have finished by now
+    joinThreads(threads)
+
+    check total == TotalItems

--- a/tests/testmpsc.nim
+++ b/tests/testmpsc.nim
@@ -89,90 +89,102 @@ suite "MPSC stress test":
     q.init()
 
   test "10000 push/pop":
-    const count = 10000
-    var nodes = newSeq[ptr TestNode](count)
+    when defined(gcOrc):
+      # TODO https://github.com/nim-lang/Nim/issues/26014
+      skip()
+    else:
+      const count = 10000
+      var nodes = newSeq[ptr TestNode](count)
 
-    # Push all
-    for i in 0 ..< count:
-      nodes[i] = newTestNode(i)
-      q.push(nodes[i])
+      # Push all
+      for i in 0 ..< count:
+        nodes[i] = newTestNode(i)
+        q.push(nodes[i])
 
-    # Pop all
-    for i in 0 ..< count:
-      let node = q.pop()
-      check node != nil
-      check node[].value == i
+      # Pop all
+      for i in 0 ..< count:
+        let node = q.pop()
+        check node != nil
+        check node[].value == i
 
-    check q.pop() == nil # Queue is empty
+      check q.pop() == nil # Queue is empty
 
-    # Cleanup
-    for node in nodes:
-      deallocShared(node)
+      # Cleanup
+      for node in nodes:
+        deallocShared(node)
 
   test "interleaved push/pop":
-    var nodes = newSeq[ptr TestNode]()
-    var popIdx = 0
+    when defined(gcOrc):
+      # TODO https://github.com/nim-lang/Nim/issues/26014
+      skip()
+    else:
+      var nodes = newSeq[ptr TestNode]()
+      var popIdx = 0
 
-    for i in 0 ..< 1000:
-      let node = newTestNode(i)
-      nodes.add(node)
-      q.push(node)
+      for i in 0 ..< 1000:
+        let node = newTestNode(i)
+        nodes.add(node)
+        q.push(node)
 
-      # Pop every other one
-      if i mod 2 == 0:
-        let popped = q.pop()
-        check popped != nil
-        check popped[].value == popIdx
+        # Pop every other one
+        if i mod 2 == 0:
+          let popped = q.pop()
+          check popped != nil
+          check popped[].value == popIdx
+          inc popIdx
+
+      # Drain remaining
+      while true:
+        let node = q.pop()
+        if node == nil:
+          break
+        check node[].value == popIdx
         inc popIdx
 
-    # Drain remaining
-    while true:
-      let node = q.pop()
-      if node == nil:
-        break
-      check node[].value == popIdx
-      inc popIdx
+      check popIdx == 1000 # All 1000 items were popped
 
-    check popIdx == 1000 # All 1000 items were popped
-
-    # Free all nodes
-    for n in nodes:
-      deallocShared(n)
+      # Free all nodes
+      for n in nodes:
+        deallocShared(n)
 
   test "multiple producers, single consumer":
-    const Producers = 8
-    const ItemsPerProducer = 10000
+    when defined(gcOrc):
+      # TODO https://github.com/nim-lang/Nim/issues/26014
+      skip()
+    else:
+      const Producers = 8
+      const ItemsPerProducer = 10000
 
-    type ProdArg = object
-      q: ptr MpscQueue[TestNode]
-      startId: int
+      type ProdArg = object
+        q: ptr MpscQueue[TestNode]
+        startId: int
 
-    var threads = newSeq[Thread[ProdArg]](Producers)
+      var threads = newSeq[Thread[ProdArg]](Producers)
 
-    proc producer(arg: ProdArg) {.thread.} =
-      for i in 0 ..< ItemsPerProducer:
-        let node = newTestNode(arg.startId * ItemsPerProducer + i)
-        arg.q[].push(node)
+      proc producer(arg: ProdArg) {.thread.} =
+        for i in 0 ..< ItemsPerProducer:
+          let node = newTestNode(arg.startId * ItemsPerProducer + i)
+          arg.q[].push(node)
 
-    for i in 0 ..< Producers:
-      let arg = ProdArg(q: addr q, startId: i)
-      createThread(threads[i], producer, arg)
+      for i in 0 ..< Producers:
+        let arg = ProdArg(q: addr q, startId: i)
+        createThread(threads[i], producer, arg)
 
-    # Wait for all producers
-    joinThreads(threads)
+      # Wait for all producers
+      joinThreads(threads)
 
-    # Verify all items were pushed
-    var total = 0
-    while true:
-      let node = q.pop()
-      if node == nil:
-        break
-      check node[].value >= 0
-      check node[].value < Producers * ItemsPerProducer
-      deallocShared(node)
-      inc total
+      # Verify all items were pushed
+      var total = 0
+      while true:
+        let node = q.pop()
+        if node == nil:
+          break
+        check node[].value >= 0
+        check node[].value < Producers * ItemsPerProducer
+        deallocShared(node)
+        inc total
 
-    check total == Producers * ItemsPerProducer
+      check total == Producers * ItemsPerProducer
 
   test "100000 items with 100 producers":
     when defined(gcOrc):

--- a/tests/testsoon.nim
+++ b/tests/testsoon.nim
@@ -91,3 +91,23 @@ suite "callSoon() tests suite":
       soonTest == 987654321
 
     check test() == true
+
+  test "cross-thread callSoon() test":
+    var crossThreadCallSoonFlag = false
+    proc crossThreadCallSoonCallback(udata: pointer) {.nimcall, gcsafe, raises: [].} =
+      cast[ptr bool](udata)[] = true
+    type T = (DispatcherHandle, ptr bool)
+    proc threadProc(disp: T) {.thread, nimcall.} =
+      callSoon(disp[0], crossThreadCallSoonCallback, disp[1])
+      callSoon(disp[0], crossThreadCallSoonCallback, disp[1])
+
+    # Pass the current thread's dispatcher pointer to a new thread
+    crossThreadCallSoonFlag = false
+    let disp = getThreadDispatcher()
+    var thread: Thread[T]
+    createThread(thread, threadProc, (disp.handle(), addr crossThreadCallSoonFlag))
+
+    # The callback was posted to the dispatcher's queue; poll to execute it
+    poll()
+    check: crossThreadCallSoonFlag == true
+    joinThreads(thread)


### PR DESCRIPTION
`callSoon` currently is well-defined for the current thread but cannot be called from a different thread.

`ThreadSignalPtr` can be used to overcome this limitation but comes with the significant downside that each signal requires its own file descriptor / handle - while this approach works for specific cases it becomes costly in a general-purpose setting such as https://github.com/status-im/nim-async-channels where each channel ends up needing its own instance.

It would in theory be possible to use a thread-local `ThreadSignalPtr` for channels in particular, but this would still not achieve the higher goal of sharing a single wake-up / notification mechanism per event loop instance.

A thread-safe `callSoon` allows threads to post work to the dispatcher of another thread and getting called back from within the scope of that thread "soon" - for example, in the AsyncChannel when a reader appears and the channel is empty, the reader can register its own dispatcher with the channel so that when a queue item appears, the channel can wake up the corresponding dispatcher and complete the future from within the correct thread-local context.

A simple unbounded MPSC queue is used for storing cross-thread callbacks - the cost is roughly equivalent to the existing `AsyncCallback` when used with a closure environment, ie one allocation per posted work item plus whatever the caller needs.

The design does not depend on the specific queue being used, ie a future version could use a ring buffer + a spill queue or similar designs that reduce allocations.

Coupled with the queue is a cross-platform "wakeup" mechanism similar to the one used in `ThreadSignalPtr` - when a callback is posted to the queue, we also make sure to wake up the dispatcher so that indeed the callback happens "soon".