### PR TITLE
ci(mobile): run test suite on Android and iOS

### DIFF
--- a/.github/scripts/ios-clang.sh
+++ b/.github/scripts/ios-clang.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${IOS_SDK_PATH:?IOS_SDK_PATH must point to the iPhone simulator SDK}"
+
+exec xcrun --sdk iphonesimulator clang \
+  -target arm64-apple-ios13.0-simulator \
+  -isysroot "$IOS_SDK_PATH" \
+  -mios-simulator-version-min=13.0 \
+  "$@"

--- a/.github/scripts/run-android-tests.sh
+++ b/.github/scripts/run-android-tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+binary="${1:?usage: run-android-tests.sh <test-binary>}"
+remote_dir="/data/local/tmp/nim-chronos"
+remote_binary="$remote_dir/$(basename "$binary")"
+
+adb shell "mkdir -p '$remote_dir'"
+adb push "$binary" "$remote_binary"
+adb shell "chmod 755 '$remote_binary'"
+adb shell "cd '$remote_dir' && '$remote_binary'"

--- a/.github/scripts/run-ios-tests.sh
+++ b/.github/scripts/run-ios-tests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+binary="${1:?usage: run-ios-tests.sh <test-binary>}"
+device_udid="${IOS_SIMULATOR_UDID:-}"
+
+if [[ -z "$device_udid" ]]; then
+  device_udid="$(
+    xcrun simctl list devices available --json | /usr/bin/python3 -c '
+import json
+import re
+import sys
+
+def runtime_version(runtime):
+    match = re.search(r"iOS-(\d+(?:[-.]\d+)*)", runtime)
+    if not match:
+        return ()
+    return tuple(int(part) for part in re.split(r"[-.]", match.group(1)))
+
+candidates = []
+for runtime, devices in json.load(sys.stdin)["devices"].items():
+    if ".iOS-" not in runtime:
+        continue
+    for device in devices:
+        if not device.get("isAvailable", True):
+            continue
+        if not device.get("name", "").startswith("iPhone"):
+            continue
+        candidates.append((runtime_version(runtime), device["udid"]))
+
+if not candidates:
+    raise SystemExit("no available iPhone simulator device")
+print(max(candidates)[1])
+'
+  )"
+fi
+
+xcrun simctl boot "$device_udid" 2>/dev/null || true
+xcrun simctl bootstatus "$device_udid" -b
+codesign --force --sign - "$binary"
+xcrun simctl spawn "$device_udid" "$(cd "$(dirname "$binary")" && pwd)/$(basename "$binary")"

--- a/.github/workflows/mobile_android.yml
+++ b/.github/workflows/mobile_android.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test-android:
-    name: Android x86_64 tests
+    name: Android x86_64 tests (Nim version-2-2)
     runs-on: ubuntu-22.04
     timeout-minutes: 60
 

--- a/.github/workflows/mobile_android.yml
+++ b/.github/workflows/mobile_android.yml
@@ -26,6 +26,7 @@ jobs:
         uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: "2.2.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: nimble --useSystemNim install -y --depsOnly

--- a/.github/workflows/mobile_android.yml
+++ b/.github/workflows/mobile_android.yml
@@ -1,0 +1,57 @@
+name: Mobile Android
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-android:
+    name: Android x86_64 tests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nim
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: "2.2.x"
+
+      - name: Install dependencies
+        run: nimble --useSystemNim install -y --depsOnly
+
+      - name: Configure Android toolchain
+        run: |
+          toolchain="$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          echo "NIMFLAGS=--os:android --cpu:amd64 --cc:clang --clang.path:$toolchain --clang.exe:x86_64-linux-android23-clang --clang.linkerexe:x86_64-linux-android23-clang --passL:-llog" >> "$GITHUB_ENV"
+
+      - name: Enable KVM for Android emulator
+        run: |
+          sudo tee /etc/udev/rules.d/99-kvm4all.rules >/dev/null <<'EOF'
+          KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"
+          EOF
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Build and run tests on Android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          NIM_TEST_RUNNER: bash .github/scripts/run-android-tests.sh
+        with:
+          api-level: 23
+          arch: x86_64
+          target: default
+          force-avd-creation: false
+          emulator-options: -no-window -no-audio -no-boot-anim -no-metrics -gpu swiftshader_indirect
+          disable-animations: true
+          script: nimble --useSystemNim test

--- a/.github/workflows/mobile_android.yml
+++ b/.github/workflows/mobile_android.yml
@@ -8,6 +8,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/mobile_android.yml
+++ b/.github/workflows/mobile_android.yml
@@ -48,6 +48,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         env:
           NIM_TEST_RUNNER: bash .github/scripts/run-android-tests.sh
+          NIM_TEST_SUCCESS_MARKER: build/mobile-tests-passed
         with:
           api-level: 23
           arch: x86_64
@@ -55,4 +56,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -no-audio -no-boot-anim -no-metrics -gpu swiftshader_indirect
           disable-animations: true
-          script: nimble --useSystemNim test
+          script: |
+            rm -f "$NIM_TEST_SUCCESS_MARKER"
+            nimble --useSystemNim test
+            test -f "$NIM_TEST_SUCCESS_MARKER"

--- a/.github/workflows/mobile_android.yml
+++ b/.github/workflows/mobile_android.yml
@@ -32,7 +32,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
-        run: nimble --useSystemNim install -y --depsOnly
+        run: nimble install -y --depsOnly
 
       - name: Configure Android toolchain
         run: |
@@ -62,5 +62,5 @@ jobs:
           script: |
             # The marker is written only after every test configuration finishes.
             rm -f "$NIM_TEST_SUCCESS_MARKER"
-            nimble --useSystemNim test
+            nimble test
             test -f "$NIM_TEST_SUCCESS_MARKER"

--- a/.github/workflows/mobile_android.yml
+++ b/.github/workflows/mobile_android.yml
@@ -49,7 +49,6 @@ jobs:
 
       - name: Build and run tests on Android emulator
         uses: reactivecircus/android-emulator-runner@v2
-        # Nimble stays on Ubuntu; this runner executes each Android binary via adb.
         env:
           NIM_TEST_RUNNER: bash .github/scripts/run-android-tests.sh
           NIM_TEST_SUCCESS_MARKER: build/mobile-tests-passed

--- a/.github/workflows/mobile_android.yml
+++ b/.github/workflows/mobile_android.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Build and run tests on Android emulator
         uses: reactivecircus/android-emulator-runner@v2
+        # Nimble stays on Ubuntu; this runner executes each Android binary via adb.
         env:
           NIM_TEST_RUNNER: bash .github/scripts/run-android-tests.sh
           NIM_TEST_SUCCESS_MARKER: build/mobile-tests-passed
@@ -60,6 +61,7 @@ jobs:
           emulator-options: -no-window -no-audio -no-boot-anim -no-metrics -gpu swiftshader_indirect
           disable-animations: true
           script: |
+            # The marker is written only after every test configuration finishes.
             rm -f "$NIM_TEST_SUCCESS_MARKER"
             nimble --useSystemNim test
             test -f "$NIM_TEST_SUCCESS_MARKER"

--- a/.github/workflows/mobile_ios.yml
+++ b/.github/workflows/mobile_ios.yml
@@ -46,10 +46,12 @@ jobs:
           echo "NIMFLAGS=--os:ios --cpu:arm64 --cc:clang --clang.path:$toolchain --clang.exe:clang --clang.linkerexe:clang --passC:-D_DARWIN_C_SOURCE" >> "$GITHUB_ENV"
 
       - name: Build and run tests on iOS simulator
+        # Nimble stays on macOS; this runner executes each iOS binary via simctl.
         env:
           NIM_TEST_RUNNER: bash .github/scripts/run-ios-tests.sh
           NIM_TEST_SUCCESS_MARKER: build/mobile-tests-passed
         run: |
+          # The marker is written only after every test configuration finishes.
           rm -f "$NIM_TEST_SUCCESS_MARKER"
           nimble --useSystemNim test
           test -f "$NIM_TEST_SUCCESS_MARKER"

--- a/.github/workflows/mobile_ios.yml
+++ b/.github/workflows/mobile_ios.yml
@@ -26,6 +26,7 @@ jobs:
         uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: "2.2.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: nimble --useSystemNim install -y --depsOnly

--- a/.github/workflows/mobile_ios.yml
+++ b/.github/workflows/mobile_ios.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test-ios:
-    name: iOS arm64 simulator tests
+    name: iOS arm64 simulator tests (Nim version-2-2)
     runs-on: macos-15
     timeout-minutes: 90
 

--- a/.github/workflows/mobile_ios.yml
+++ b/.github/workflows/mobile_ios.yml
@@ -1,0 +1,51 @@
+name: Mobile iOS
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-ios:
+    name: iOS arm64 simulator tests
+    runs-on: macos-15
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nim
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: "2.2.x"
+
+      - name: Install dependencies
+        run: nimble --useSystemNim install -y --depsOnly
+
+      - name: Configure iOS simulator toolchain
+        run: |
+          toolchain="$RUNNER_TEMP/ios-toolchain"
+          mkdir -p "$toolchain"
+          ln -s "$GITHUB_WORKSPACE/.github/scripts/ios-clang.sh" "$toolchain/clang"
+          ln -s "$GITHUB_WORKSPACE/.github/scripts/ios-clang.sh" "$toolchain/clang++"
+          chmod +x "$GITHUB_WORKSPACE/.github/scripts/ios-clang.sh"
+          echo "IOS_NIM_TOOLCHAIN=$toolchain" >> "$GITHUB_ENV"
+          echo "IOS_SDK_PATH=$(xcrun --sdk iphonesimulator --show-sdk-path)" >> "$GITHUB_ENV"
+          echo "NIMFLAGS=--os:ios --cpu:arm64 --cc:clang --clang.path:$toolchain --clang.exe:clang --clang.linkerexe:clang --passC:-D_DARWIN_C_SOURCE" >> "$GITHUB_ENV"
+
+      - name: Build and run tests on iOS simulator
+        env:
+          NIM_TEST_RUNNER: bash .github/scripts/run-ios-tests.sh
+        run: nimble --useSystemNim test
+
+      - name: Shut down simulator
+        if: always()
+        run: xcrun simctl shutdown all || true

--- a/.github/workflows/mobile_ios.yml
+++ b/.github/workflows/mobile_ios.yml
@@ -8,6 +8,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/mobile_ios.yml
+++ b/.github/workflows/mobile_ios.yml
@@ -32,7 +32,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
-        run: nimble --useSystemNim install -y --depsOnly
+        run: nimble install -y --depsOnly
 
       - name: Configure iOS simulator toolchain
         run: |
@@ -52,7 +52,7 @@ jobs:
         run: |
           # The marker is written only after every test configuration finishes.
           rm -f "$NIM_TEST_SUCCESS_MARKER"
-          nimble --useSystemNim test
+          nimble test
           test -f "$NIM_TEST_SUCCESS_MARKER"
 
       - name: Shut down simulator

--- a/.github/workflows/mobile_ios.yml
+++ b/.github/workflows/mobile_ios.yml
@@ -45,7 +45,11 @@ jobs:
       - name: Build and run tests on iOS simulator
         env:
           NIM_TEST_RUNNER: bash .github/scripts/run-ios-tests.sh
-        run: nimble --useSystemNim test
+          NIM_TEST_SUCCESS_MARKER: build/mobile-tests-passed
+        run: |
+          rm -f "$NIM_TEST_SUCCESS_MARKER"
+          nimble --useSystemNim test
+          test -f "$NIM_TEST_SUCCESS_MARKER"
 
       - name: Shut down simulator
         if: always()

--- a/.github/workflows/mobile_ios.yml
+++ b/.github/workflows/mobile_ios.yml
@@ -46,7 +46,6 @@ jobs:
           echo "NIMFLAGS=--os:ios --cpu:arm64 --cc:clang --clang.path:$toolchain --clang.exe:clang --clang.linkerexe:clang --passC:-D_DARWIN_C_SOURCE" >> "$GITHUB_ENV"
 
       - name: Build and run tests on iOS simulator
-        # Nimble stays on macOS; this runner executes each iOS binary via simctl.
         env:
           NIM_TEST_RUNNER: bash .github/scripts/run-ios-tests.sh
           NIM_TEST_SUCCESS_MARKER: build/mobile-tests-passed

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -51,6 +51,7 @@ proc run(args, path: string) =
   if testRunner.len == 0:
     exec executable
   else:
+    # Cross-compiled tests need adb or simctl instead of direct host execution.
     exec testRunner & " " & quoteShell(executable)
 
 proc tryExec(cmd: string) =
@@ -95,6 +96,7 @@ task test, "Run all tests":
       build "", f[0..^5]
 
   if testSuccessMarker.len > 0:
+    # Mobile CI uses this to confirm that the full task reached its end.
     writeFile(testSuccessMarker, "")
 
 task test_v3_compat, "Run all tests in v3 compatibility mode":

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -22,6 +22,7 @@ let flags = getEnv("NIMFLAGS", "") # Extra flags for the compiler
 let verbose = getEnv("V", "") notin ["", "0"]
 let platform = getEnv("PLATFORM", "")
 let testRunner = getEnv("NIM_TEST_RUNNER", "")
+let testSuccessMarker = getEnv("NIM_TEST_SUCCESS_MARKER", "")
 let testArguments =
   when defined(windows):
     [
@@ -92,6 +93,9 @@ task test, "Run all tests":
   for f in walkDirRec("benchmarks"):
     if f.startsWith("bench_") and f.endsWith(".nim"):
       build "", f[0..^5]
+
+  if testSuccessMarker.len > 0:
+    writeFile(testSuccessMarker, "")
 
 task test_v3_compat, "Run all tests in v3 compatibility mode":
   for args in testArguments:

--- a/chronos.nimble
+++ b/chronos.nimble
@@ -21,6 +21,7 @@ let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)
 let flags = getEnv("NIMFLAGS", "") # Extra flags for the compiler
 let verbose = getEnv("V", "") notin ["", "0"]
 let platform = getEnv("PLATFORM", "")
+let testRunner = getEnv("NIM_TEST_RUNNER", "")
 let testArguments =
   when defined(windows):
     [
@@ -45,7 +46,11 @@ proc build(args, path: string) =
 
 proc run(args, path: string) =
   build args, path
-  exec "build/" & path.splitPath[1]
+  let executable = "build/" & path.splitPath[1]
+  if testRunner.len == 0:
+    exec executable
+  else:
+    exec testRunner & " " & quoteShell(executable)
 
 proc tryExec(cmd: string) =
   try:

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -17,8 +17,13 @@ import
   ]
 
 when (chronosEventEngine in ["epoll", "kqueue"]) or defined(windows):
-  # `poll` engine do not support signals and processes
-  import ./[testsignal, testproc]
+  # `poll` engine does not support signals and processes.
+  import testsignal
+
+  # Mobile test binaries cannot execute the host-side helper scripts used by
+  # the process tests.
+  when not (defined(android) or defined(ios)):
+    import testproc
 
   # Must be imported last to check for Pending futures
   import testutils

--- a/tests/teststream.nim
+++ b/tests/teststream.nim
@@ -1340,7 +1340,7 @@ suite "Stream Transport test suite":
       check ok
 
     asyncTest prefixes[i] & "accept() too many file descriptors test":
-      when defined(windows):
+      when defined(windows) or defined(android):
         skip()
       else:
         let maxFiles = getMaxOpenFiles()

--- a/tests/teststream.nim
+++ b/tests/teststream.nim
@@ -22,7 +22,7 @@ proc getCurrentFD(): int =
   closeSocket(sock)
   return int(sock)
 
-func filesTestName(): string =
+proc filesTestName(): string =
   when defined(android) or defined(ios):
     # Source paths refer to the CI host and are not visible inside a mobile
     # simulator. The running binary is a convenient non-empty local file.

--- a/tests/teststream.nim
+++ b/tests/teststream.nim
@@ -22,6 +22,14 @@ proc getCurrentFD(): int =
   closeSocket(sock)
   return int(sock)
 
+func filesTestName(): string =
+  when defined(android) or defined(ios):
+    # Source paths refer to the CI host and are not visible inside a mobile
+    # simulator. The running binary is a convenient non-empty local file.
+    getAppFilename()
+  else:
+    currentSourcePath
+
 suite "Stream Transport test suite":
   let markFD = getCurrentFD()
 
@@ -38,7 +46,6 @@ suite "Stream Transport test suite":
   const
     ConstantMessage = "SOMEDATA"
     BigMessagePattern = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    FilesTestName = currentSourcePath
     BigMessageCount = 100
     ClientsCount = 5
     MessagesCount = 10
@@ -50,6 +57,11 @@ suite "Stream Transport test suite":
     let addresses = [
       initTAddress("127.0.0.1:33335"),
       initTAddress(r"/LOCAL\testpipe")
+    ]
+  elif defined(android):
+    let addresses = [
+      initTAddress("127.0.0.1:0"),
+      initTAddress(getAppDir() / "testpipe")
     ]
   else:
     let addresses = [
@@ -850,9 +862,9 @@ suite "Stream Transport test suite":
           var transp = await connect(address)
           var ssize: string
           var handle = 0
-          var name = FilesTestName
-          var size = int(getFileSize(FilesTestName))
-          var fhandle = open(FilesTestName)
+          var name = filesTestName()
+          var size = int(getFileSize(filesTestName()))
+          var fhandle = open(filesTestName())
           when defined(windows):
             handle = int(get_osfhandle(getFileHandle(fhandle)))
           else:


### PR DESCRIPTION
Add dedicated GitHub Actions workflows that cross-compile and run `nimble test` on:

- Android x86_64 using an emulator
- iOS arm64 using a simulator

The Nimble test task now supports an optional external test runner so mobile binaries can be executed through `adb` or `simctl`. Mobile-specific test handling avoids host-only paths and excludes process tests that depend on host-side helper scripts.
