### PR TITLE
testsoon: drain both cross-thread callbacks before the test returns

### DIFF
--- a/tests/testsoon.nim
+++ b/tests/testsoon.nim
@@ -93,21 +93,23 @@ suite "callSoon() tests suite":
     check test() == true
 
   test "cross-thread callSoon() test":
-    var crossThreadCallSoonFlag = false
+    var crossThreadCallSoonCount = 0
     proc crossThreadCallSoonCallback(udata: pointer) {.nimcall, gcsafe, raises: [].} =
-      cast[ptr bool](udata)[] = true
-    type T = (DispatcherHandle, ptr bool)
+      cast[ptr int](udata)[] += 1
+    type T = (DispatcherHandle, ptr int)
     proc threadProc(disp: T) {.thread, nimcall.} =
       callSoon(disp[0], crossThreadCallSoonCallback, disp[1])
       callSoon(disp[0], crossThreadCallSoonCallback, disp[1])
 
     # Pass the current thread's dispatcher pointer to a new thread
-    crossThreadCallSoonFlag = false
     let disp = getThreadDispatcher()
     var thread: Thread[T]
-    createThread(thread, threadProc, (disp.handle(), addr crossThreadCallSoonFlag))
+    createThread(thread, threadProc, (disp.handle(), addr crossThreadCallSoonCount))
 
-    # The callback was posted to the dispatcher's queue; poll to execute it
-    poll()
-    check: crossThreadCallSoonFlag == true
+    # Callbacks and wake-ups don't map 1:1 to polls, so poll until both
+    # callbacks have run; a callback left queued past this test would
+    # fire later through a pointer into this frame
+    while crossThreadCallSoonCount < 2:
+      poll()
+    check: crossThreadCallSoonCount == 2
     joinThreads(thread)


### PR DESCRIPTION
The cross-thread callSoon test added in #694 has a race that leaves a callback queued after the test returns, carrying a pointer into the test's dead stack frame. On linux-i386 CI this aborts `testall` with `*** stack smashing detected ***` at the start of the timers suite, at a rate of roughly one run in ten. On other targets the same write lands silently.

The test takes `addr` of a stack-local flag, spawns a thread that posts two cross-thread callbacks with that pointer, and calls `poll()` once, without joining the thread first:

- The first push sets the dispatcher's `waking` flag and wakes the loop; the second push sees the flag still set and skips the wake, as designed.
- `processThreadCallbacks` clears `waking` and then drains the MPSC queue. If the drain lands between the two pushes, it moves only the first callback; the second push then re-arms the wake and stays queued for the next poll cycle.
- The single `poll()` runs callback one, the flag reads true, the check passes, and the test returns. The frame that owned the flag is gone.
- The next `poll()` anywhere in the process fires the leftover callback, which writes `true` through the dangling pointer.

In `testall`, the next poll is the timers suite's first `waitFor`. On linux-i386 the written byte lands on that `waitFor` frame's stack canary, which is what the CI failures show: `stack smashing detected`, SIGABRT, traceback ending at `testtime.nim` `testTimer`, always at timers-suite entry, on both Nim 1.6 and devel.

Diagnosis is from a core dump of the faithful CI build (`nimble test` first config plus `-g`, no other changes, no debugger attached, looped on a CI runner until it crashed): the canary slot held `0x59014c00` against a per-thread canary of `0x59104c00` read intact from neighboring frames, a single byte changed from `0x10` to `0x01` at canary offset 2, with the adjacent frame-trace record untouched. A one-byte `0x01` store through a stale pointer is exactly `flag = true`.

Whether the stray write crashes depends on where the byte lands, which varies with binary layout, so the crash itself comes and goes across otherwise-unrelated commits. Instrumenting the test settles the question directly: resetting the flag after the existing check and giving the loop one more spin before the frame dies shows the second callback stranded in 19 of 500 runs of the otherwise unmodified test at master (b71392a), on x86_64. The race is in the test as written; linux-i386 is merely where the consequence is visible.

The fix makes the test deterministic: count the callbacks instead of latching a bool, join the thread before polling so both posts are visible to the drain, and poll until both have run. Nothing queued can then outlive the frame it points into, and the test now fails loudly if either callback is dropped, which the old bool could not detect. Verified with 40 consecutive clean runs of the standalone binary and 120 clean iterations of the previously-crashing linux-i386 CI loop on the fixed commit (https://github.com/coreyleavitt/chronos/actions/runs/31351631105); the same loop on unfixed commits crashes within 8 to 55 iterations.

Found while running CI for #702.
